### PR TITLE
recognize require('foo/bar') as a dependency on foo

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,10 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
       if (util.isError(modulesRequired)) {
         invalidFiles[filename] = modulesRequired;
       } else {
-        deps = deps.difference(modulesRequired.valueOf());
+        modulesRequired = modulesRequired.map(function (module) {
+          return module.replace(/\/.*$/, '');
+        });
+        deps = deps.difference(modulesRequired);
         devDeps = devDeps.difference(modulesRequired);
       }
     }

--- a/test/fake_modules/nested/index.js
+++ b/test/fake_modules/nested/index.js
@@ -1,0 +1,1 @@
+var pkg = require("optimist/package.json");

--- a/test/fake_modules/nested/package.json
+++ b/test/fake_modules/nested/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "optimist": "~0.6.0"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -76,4 +76,13 @@ describe("depcheck", function () {
     });
   });
 
+  it("should recognize nested requires", function testNested(done) {
+    var absolutePath = path.resolve("test/fake_modules/nested");
+
+    depcheck(absolutePath, {  }, function checked(unused) {
+      assert.equal(unused.dependencies.length, 0);
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
The node docs don't call it out, but requiring arbitrary files from within a node module works just fine.
