### PR TITLE
Update the badges and builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: node_js
 
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ node_js:
   - 'node'
 
 script:
-  - npm run depcheck-web
+  - npm run depcheck
   - npm run lint
   - npm run test-coverage
   - cat ./coverage/coverage.json | ./node_modules/codecov.io/bin/codecov.io.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ node_js:
 script:
   - npm run depcheck-web
   - npm run lint
-  - npm run test-coveralls
-  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+  - npm run test-coverage
+  - cat ./coverage/coverage.json | ./node_modules/codecov.io/bin/codecov.io.js
 
 before_deploy:
   - npm run patch-version

--- a/README.md
+++ b/README.md
@@ -6,13 +6,12 @@ And that is why `depcheck` exists - it's a nifty little tool that looks at your 
 
 ## Build Status
 
-[![build status](https://secure.travis-ci.org/lijunle/depcheck-es6.svg?branch=master)](http://travis-ci.org/lijunle/depcheck-es6)
-[![Build status](https://ci.appveyor.com/api/projects/status/w774aev2mj0s2hlf/branch/master?svg=true)](https://ci.appveyor.com/project/lijunle/depcheck-es6/branch/master)
-[![Coverage Status](https://coveralls.io/repos/lijunle/depcheck-es6/badge.svg?branch=master&service=github)](https://coveralls.io/github/lijunle/depcheck-es6?branch=master)
+[![Build Status](https://travis-ci.org/depcheck/depcheck.svg?branch=master)](https://travis-ci.org/depcheck/depcheck)
+[![Build status](https://ci.appveyor.com/api/projects/status/xbooh370dinuyi0y/branch/master?svg=true)](https://ci.appveyor.com/project/lijunle/depcheck/branch/master)
+[![codecov.io](https://codecov.io/github/depcheck/depcheck/coverage.svg?branch=master)](https://codecov.io/github/depcheck/depcheck?branch=master)
 
-[![Depcheck](https://depcheck.tk/github/lijunle/depcheck-es6/master.svg)](https://github.com/lijunle/depcheck-es6)
-[![Dependency Status](https://david-dm.org/lijunle/depcheck-es6.svg)](https://david-dm.org/lijunle/depcheck-es6)
-[![devDependency Status](https://david-dm.org/lijunle/depcheck-es6/dev-status.svg)](https://david-dm.org/lijunle/depcheck-es6#info=devDependencies)
+[![Dependency Status](https://david-dm.org/depcheck/depcheck.svg)](https://david-dm.org/depcheck/depcheck)
+[![devDependency Status](https://david-dm.org/depcheck/depcheck/dev-status.svg)](https://david-dm.org/depcheck/depcheck#info=devDependencies)
 
 ## Installation
 
@@ -42,7 +41,7 @@ All the arguments are optional:
 
 `--help`: Show the help message.
 
-`--parsers`, `--detectors` and `--specials`: These arguments are for advanced usage. They provide an easy way to customize the file parser and dependency detection. Check [the pluggable design document](https://github.com/lijunle/depcheck-es6/blob/master/doc/pluggable-design.md) for more information.
+`--parsers`, `--detectors` and `--specials`: These arguments are for advanced usage. They provide an easy way to customize the file parser and dependency detection. Check [the pluggable design document](https://github.com/depcheck/depcheck/blob/master/doc/pluggable-design.md) for more information.
 
 ## API
 

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "prepublish": "npm run compile && npm run component",
     "lint": "eslint ./src ./test ./build",
     "test": "mocha --compilers js:babel/register ./test ./test/special",
-    "test-coverage": "babel-node ./node_modules/.bin/isparta cover node_modules/mocha/bin/_mocha -- ./test ./test/special",
-    "test-coveralls": "babel-node ./node_modules/.bin/isparta cover node_modules/mocha/bin/_mocha --report lcovonly -- ./test ./test/special -R spec"
+    "test-coverage": "babel-node ./node_modules/.bin/isparta cover node_modules/mocha/bin/_mocha -- ./test ./test/special"
   },
   "author": [
     "Djordje Lukic <lukic.djordje@gmail.com>",
@@ -42,7 +41,7 @@
   "devDependencies": {
     "babel": "^5.8.23",
     "babel-eslint": "^4.1.3",
-    "coveralls": "^2.11.4",
+    "codecov.io": "^0.1.6",
     "eslint": "^1.7.3",
     "eslint-config-airbnb": "0.1.0",
     "isparta": "^3.0.4",


### PR DESCRIPTION
- Update the Travis CI and AppVeyor builds and badges.
- Enable container-based build in Travis CI.
- Migrate the code coverage service to http://codecov.io
- Disable depcheck service because it does not support organization repo now.