### PR TITLE
Implement Babel plugin and presets support.

### DIFF
--- a/src/special/babel.js
+++ b/src/special/babel.js
@@ -30,15 +30,23 @@ function filter(deps, options) {
   return presets.concat(plugins);
 }
 
+function getFromOptions(deps, options) {
+  const optDeps = filter(deps, options);
+  const envDeps = values(options.env).map(env => filter(deps, env))
+    .reduce((array, item) => array.concat(item), []);
+
+  return optDeps.concat(envDeps);
+}
+
 export default (content, filename, deps) => {
   if (filename === '.babelrc') {
     const options = JSON.parse(content);
+    return getFromOptions(deps, options);
+  }
 
-    const optDeps = filter(deps, options);
-    const envDeps = values(options.env).map(env => filter(deps, env))
-      .reduce((array, item) => array.concat(item), []);
-
-    return optDeps.concat(envDeps);
+  if (filename === 'package.json') {
+    const metadata = JSON.parse(content);
+    return getFromOptions(deps, metadata.babel);
   }
 
   return [];

--- a/src/special/babel.js
+++ b/src/special/babel.js
@@ -3,13 +3,14 @@ function contain(array, dep, prefix) {
     return false;
   }
 
-  if (array.indexOf(dep) !== -1) {
+  // extract name if wrapping with options
+  const names = array.map(item => typeof item === 'string' ? item : item[0]);
+  if (names.indexOf(dep) !== -1) {
     return true;
   }
 
-  if (dep.indexOf(prefix) === 0 &&
-      array.indexOf(dep.substring(prefix.length)) !== -1) {
-    return true;
+  if (prefix && dep.indexOf(prefix) === 0) {
+    return contain(array, dep.substring(prefix.length), false);
   }
 
   return false;

--- a/src/special/babel.js
+++ b/src/special/babel.js
@@ -1,0 +1,32 @@
+function contain(array, dep, prefix) {
+  if (!array) {
+    return false;
+  }
+
+  if (array.indexOf(dep) !== -1) {
+    return true;
+  }
+
+  if (dep.indexOf(prefix) === 0 &&
+      array.indexOf(dep.substring(prefix.length)) !== -1) {
+    return true;
+  }
+
+  return false;
+}
+
+export default (content, filename, deps) => {
+  if (filename === '.babelrc') {
+    const options = JSON.parse(content);
+
+    const presets = deps.filter(dep =>
+      contain(options.presets, dep, 'babel-preset-'));
+
+    const plugins = deps.filter(dep =>
+      contain(options.plugins, dep, 'babel-plugin-'));
+
+    return presets.concat(plugins);
+  }
+
+  return [];
+};

--- a/src/special/babel.js
+++ b/src/special/babel.js
@@ -1,3 +1,7 @@
+function values(object) {
+  return Object.keys(object || {}).map(key => object[key]);
+}
+
 function contain(array, dep, prefix) {
   if (!array) {
     return false;
@@ -16,17 +20,25 @@ function contain(array, dep, prefix) {
   return false;
 }
 
+function filter(deps, options) {
+  const presets = deps.filter(dep =>
+    contain(options.presets, dep, 'babel-preset-'));
+
+  const plugins = deps.filter(dep =>
+    contain(options.plugins, dep, 'babel-plugin-'));
+
+  return presets.concat(plugins);
+}
+
 export default (content, filename, deps) => {
   if (filename === '.babelrc') {
     const options = JSON.parse(content);
 
-    const presets = deps.filter(dep =>
-      contain(options.presets, dep, 'babel-preset-'));
+    const optDeps = filter(deps, options);
+    const envDeps = values(options.env).map(env => filter(deps, env))
+      .reduce((array, item) => array.concat(item), []);
 
-    const plugins = deps.filter(dep =>
-      contain(options.plugins, dep, 'babel-plugin-'));
-
-    return presets.concat(plugins);
+    return optDeps.concat(envDeps);
   }
 
   return [];

--- a/test/special/babel.js
+++ b/test/special/babel.js
@@ -60,4 +60,12 @@ describe('babel special parser', () => {
   testCases.forEach(testCase =>
     it(`should ${testCase.name} in .babelrc file`, () =>
       testBabel('.babelrc', testCase.deps, testCase.options)));
+
+  testCases.forEach(testCase =>
+    it(`should ${testCase.name} inside .babelrc file env section`, () =>
+      testBabel('.babelrc', testCase.deps, {
+        env: {
+          production: testCase.options,
+        },
+      })));
 });

--- a/test/special/babel.js
+++ b/test/special/babel.js
@@ -57,6 +57,15 @@ describe('babel special parser', () => {
     result.should.deepEqual([]);
   });
 
+  it('should recognize dependencies not a babel plugin', () => {
+    const content = JSON.stringify({
+      presets: ['es2015'],
+    });
+
+    const result = parse(content, '.babelrc', ['babel-preset-es2015', 'dep']);
+    result.should.deepEqual(['babel-preset-es2015']);
+  });
+
   testCases.forEach(testCase =>
     it(`should ${testCase.name} in .babelrc file`, () =>
       testBabel('.babelrc', testCase.deps, testCase.options)));

--- a/test/special/babel.js
+++ b/test/special/babel.js
@@ -1,0 +1,51 @@
+/* global describe, it */
+
+import 'should';
+import parse from '../../src/special/babel';
+
+const testCases = [
+  {
+    name: 'recognize the short-name plugin',
+    deps: ['babel-plugin-syntax-jsx'],
+    options: {
+      plugins: ['syntax-jsx'],
+    },
+  },
+  {
+    name: 'recognize the long-name plugin',
+    deps: ['babel-plugin-syntax-jsx'],
+    options: {
+      plugins: ['babel-plugin-syntax-jsx'],
+    },
+  },
+  {
+    name: 'recognize the short-name preset',
+    deps: ['babel-preset-es2015'],
+    options: {
+      presets: ['es2015'],
+    },
+  },
+  {
+    name: 'recognize the long-name preset',
+    deps: ['babel-preset-es2015'],
+    options: {
+      presets: ['babel-preset-es2015'],
+    },
+  },
+];
+
+function testBabel(filename, deps, content) {
+  const result = parse(JSON.stringify(content), filename, deps);
+  result.should.deepEqual(deps);
+}
+
+describe('babel special parser', () => {
+  it('should ignore when filename is not supported', () => {
+    const result = parse('content', 'not-supported.txt', ['deps']);
+    result.should.deepEqual([]);
+  });
+
+  testCases.forEach(testCase =>
+    it(`should ${testCase.name} in .babelrc file`, () =>
+      testBabel('.babelrc', testCase.deps, testCase.options)));
+});

--- a/test/special/babel.js
+++ b/test/special/babel.js
@@ -32,6 +32,18 @@ const testCases = [
       presets: ['babel-preset-es2015'],
     },
   },
+  {
+    name: 'recognize plugin specified with options',
+    deps: ['babel-plugin-transform-async-to-module-method'],
+    options: {
+      plugins: [
+        ['transform-async-to-module-method', {
+          module: 'bluebird',
+          method: 'coroutine',
+        }],
+      ],
+    },
+  },
 ];
 
 function testBabel(filename, deps, content) {

--- a/test/special/babel.js
+++ b/test/special/babel.js
@@ -68,4 +68,24 @@ describe('babel special parser', () => {
           production: testCase.options,
         },
       })));
+
+  testCases.forEach(testCase =>
+    it(`should ${testCase.name} in package.json file`, () =>
+      testBabel('package.json', testCase.deps, {
+        name: 'my-package',
+        version: '1.0.0',
+        babel: testCase.options,
+      })));
+
+  testCases.forEach(testCase =>
+    it(`should ${testCase.name} inside .babelrc file env section`, () =>
+      testBabel('package.json', testCase.deps, {
+        name: 'my-package',
+        version: '1.0.0',
+        babel: {
+          env: {
+            development: testCase.options,
+          },
+        },
+      })));
 });


### PR DESCRIPTION
- Close https://github.com/lijunle/depcheck-es6/issues/97
- The configs in `.babelrc` file.
- Configs with options ([example](https://babeljs.io/docs/plugins/#options)).
- The configs in envionment ([example](https://babeljs.io/docs/usage/babelrc/#env-option)).
- The configs in `package.json` ([example](https://babeljs.io/docs/usage/babelrc/#use-via-package-json)).

It is **not** going to support the following because they involve more affect to support them. Open an issue and let me know the reason if you have a full scenario.

- The configs in Babel CLI.
- The configs in API calls.