### PR TITLE
Update Babylon parser to 6.x version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "babel-runtime": "^5.8.34",
-    "babylon": "^5.8.29",
+    "babylon": "^6.1.21",
     "deps-regex": "^0.1.4",
     "js-yaml": "^3.4.2",
     "minimatch": "^3.0.0",

--- a/src/component.json
+++ b/src/component.json
@@ -2,6 +2,7 @@
   "notice": "This file is for debugging and testing only, the production one is built from `build/component.js` script.",
   "parser": [
     "es6",
+    "es7",
     "jsx",
     "coffee"
   ],

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ const defaultOptions = {
     'bower_components',
   ],
   parsers: {
-    '*.js': availableParsers.jsx,
+    '*.js': availableParsers.es7,
     '*.jsx': availableParsers.jsx,
     '*.coffee': availableParsers.coffee,
     '*.litcoffee': availableParsers.coffee,

--- a/src/parser/es6.js
+++ b/src/parser/es6.js
@@ -1,23 +1,6 @@
 import { parse } from 'babylon';
 
-export const config = {
-  sourceType: 'module',
-  features: {
-    // Enable all possible experimental features.
-    // Because we only parse them, not evaluate any code, it is safe to do so.
-    // Reference Babel docs: https://babeljs.io/docs/usage/experimental/
-    'es7.asyncFunctions': true,
-    'es7.classProperties': true,
-    'es7.comprehensions': true,
-    'es7.decorators': true,
-    'es7.doExpressions': true,
-    'es7.exponentiationOperator': true,
-    'es7.exportExtensions': true,
-    'es7.functionBind': true,
-    'es7.objectRestSpread': true,
-    'es7.trailingFunctionCommas': true,
-  },
-};
-
 export default content =>
-  parse(content, config);
+  parse(content, {
+    sourceType: 'module',
+  });

--- a/src/parser/es7.js
+++ b/src/parser/es7.js
@@ -5,6 +5,6 @@ export default content =>
     sourceType: 'module',
 
     // Enable all possible babylon plugins.
-    // Because the guys using React always want the newest syntax.
-    plugins: ['*', 'jsx'],
+    // Because we only parse them, not evaluate any code, it is safe to do so.
+    plugins: ['*'],
   });


### PR DESCRIPTION
- Split the ES6 and ES7 syntax to two different parsers.
- Ship ES7 as the default parser.