### PR TITLE
Remove babel runtime dep

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
   "plugins": [
     "add-module-exports",
-    "transform-runtime"
+    "transform-object-assign"
   ],
   "presets": [
     "es2015",

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 language: node_js
 
 node_js:
+  - 0.12
+  - 3
   - 4
   - 5
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 environment:
   matrix:
+  - nodejs_version: 0.12
+  - nodejs_version: 3
   - nodejs_version: 4
   - nodejs_version: 5
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "babel-runtime": "^5.8.34",
     "babylon": "^6.1.21",
     "deps-regex": "^0.1.4",
     "js-yaml": "^3.4.2",
@@ -52,7 +51,7 @@
     "babel-cli": "^6.1.1",
     "babel-eslint": "^4.1.3",
     "babel-plugin-add-module-exports": "^0.1.1",
-    "babel-plugin-transform-runtime": "^6.1.18",
+    "babel-plugin-transform-object-assign": "^6.1.18",
     "babel-preset-es2015": "^6.0.15",
     "babel-preset-stage-2": "^6.0.15",
     "codecov.io": "^0.1.6",


### PR DESCRIPTION
- Assert back the old version (0.12 and 3.x) support. However, 0.10 is not supported.
- Install babel-plugin-transform-object-assign to support node 0.12.