### PR TITLE
Refine the bin special parser to be stable.

### DIFF
--- a/src/special/bin.js
+++ b/src/special/bin.js
@@ -1,52 +1,61 @@
 import path from 'path';
 import yaml from 'js-yaml';
 
-function getObjectValues(obj) {
-  return Object.keys(obj).map(key => obj[key]);
+function getObjectValues(object) {
+  return Object.keys(object).map(key => object[key]);
 }
 
-function join(...args) {
-  return path.join(...args).replace(/\\/g, '/');
+function toKeyValuePair(object) {
+  return Object.keys(object).map(key => ({ key, value: object[key] }));
 }
 
-function getBin(dir, dependency) {
-  const packagePath = path.resolve(dir, 'node_modules', dependency, 'package.json');
+function toMetadata(dep, dir) {
+  const packagePath = path.resolve(dir, 'node_modules', dep, 'package.json');
   const metadata = require(packagePath);
-  return metadata.bin || {};
+  const binaryLookup = metadata.bin || {};
+  const binaries = toKeyValuePair(binaryLookup);
+
+  return { dep, binaries };
 }
 
-function isUsing(dep, bin, value, scripts) {
-  const concretePath = join('node_modules', dep, value);
-  const characteristics = [
-    bin,
-    `$(npm bin)/${bin}`,
-    `node_modules/.bin/${bin}`,
-    `./node_modules/.bin/${bin}`,
-    concretePath,
-    `./${concretePath}`,
+function getBinFeatures(dep, bin) {
+  const binPath = path.join('node_modules', dep, bin.value).replace(/\\/g, '/');
+
+  const features = [
+    bin.key,
+    `$(npm bin)/${bin.key}`,
+    `node_modules/.bin/${bin.key}`,
+    `./node_modules/.bin/${bin.key}`,
+    binPath,
+    `./${binPath}`,
   ];
 
-  return scripts.some(script =>
-    characteristics.some(char => ` ${script} `.indexOf(` ${char} `) !== -1));
+  return features;
 }
 
-function depsUsedByScripts(deps, scripts, dir) {
-  return deps.filter(dep => {
-    const bin = getBin(dir, dep);
-    return Object.keys(bin).some(key =>
-      isUsing(dep, key, bin[key], scripts));
-  });
+function isUsedBin(dep, bin, scripts) {
+  const features = getBinFeatures(dep, bin);
+  return scripts.some(script =>
+    features.some(char => ` ${script} `.indexOf(` ${char} `) !== -1));
+}
+
+function getUsedDeps(deps, scripts, dir) {
+  return deps
+  .map(dep => toMetadata(dep, dir))
+  .filter(metadata =>
+    metadata.binaries.some(bin => isUsedBin(metadata.dep, bin, scripts)))
+  .map(metadata => metadata.dep);
 }
 
 export default (content, filename, deps, dir) => {
   const basename = path.basename(filename);
   if (basename === 'package.json') {
     const scripts = getObjectValues(JSON.parse(content).scripts || {});
-    return depsUsedByScripts(deps, scripts, dir);
+    return getUsedDeps(deps, scripts, dir);
   } else if (basename === '.travis.yml') {
     const metadata = yaml.safeLoad(content) || {};
     const scripts = metadata.script || [];
-    return depsUsedByScripts(deps, scripts, dir);
+    return getUsedDeps(deps, scripts, dir);
   }
 
   return [];

--- a/src/special/bin.js
+++ b/src/special/bin.js
@@ -18,6 +18,7 @@ function getBin(dir, dependency) {
 function isUsing(dep, bin, value, scripts) {
   return scripts.some(script =>
     script.indexOf(bin) === 0 ||
+    script.indexOf(`$(npm bin)/${bin}`) !== -1 ||
     script.indexOf(`./node_modules/.bin/${bin}`) !== -1 ||
     script.indexOf(join('node_modules', dep, value)) !== -1);
 }

--- a/src/special/bin.js
+++ b/src/special/bin.js
@@ -19,6 +19,7 @@ function isUsing(dep, bin, value, scripts) {
   return scripts.some(script =>
     script.indexOf(bin) === 0 ||
     script.indexOf(`$(npm bin)/${bin}`) !== -1 ||
+    script.indexOf(`node_modules/.bin/${bin}`) !== -1 ||
     script.indexOf(`./node_modules/.bin/${bin}`) !== -1 ||
     script.indexOf(join('node_modules', dep, value)) !== -1);
 }

--- a/src/special/bin.js
+++ b/src/special/bin.js
@@ -16,12 +16,18 @@ function getBin(dir, dependency) {
 }
 
 function isUsing(dep, bin, value, scripts) {
+  const concretePath = join('node_modules', dep, value);
+  const characteristics = [
+    bin,
+    `$(npm bin)/${bin}`,
+    `node_modules/.bin/${bin}`,
+    `./node_modules/.bin/${bin}`,
+    concretePath,
+    `./${concretePath}`,
+  ];
+
   return scripts.some(script =>
-    script.indexOf(bin) === 0 ||
-    script.indexOf(`$(npm bin)/${bin}`) !== -1 ||
-    script.indexOf(`node_modules/.bin/${bin}`) !== -1 ||
-    script.indexOf(`./node_modules/.bin/${bin}`) !== -1 ||
-    script.indexOf(join('node_modules', dep, value)) !== -1);
+    characteristics.some(char => ` ${script} `.indexOf(` ${char} `) !== -1));
 }
 
 function depsUsedByScripts(deps, scripts, dir) {

--- a/test/special/bin.js
+++ b/test/special/bin.js
@@ -13,20 +13,19 @@ describe('bin special parser', () => {
   function testBinSpecialParser(filename, serializer) {
     function testScript(script, dependencies) {
       const content = serializer(script);
-      const deps = dependencies || ['anybin'];
-      const dir = path.resolve(__dirname, '../fake_modules/bin_js');
-      const result = binSpecialParser(content, filename, deps, dir);
+      const deps = dependencies || ['binary-package'];
+      const result = binSpecialParser(content, filename, deps, __dirname);
       return result;
     }
 
     it('should detect packages used in scripts', () =>
-      testScript('any --bin').should.deepEqual(['anybin']));
+      testScript('binary-entry --argument').should.deepEqual(['binary-package']));
 
     it('should detect packages used as `.bin` path', () =>
-      testScript('./node_modules/.bin/any').should.deepEqual(['anybin']));
+      testScript('./node_modules/.bin/binary-entry').should.deepEqual(['binary-package']));
 
     it('should detect packages used as package path', () =>
-      testScript('./node_modules/anybin/bin/bin').should.deepEqual(['anybin']));
+      testScript('./node_modules/binary-package/bin/binary-exe').should.deepEqual(['binary-package']));
 
     it('should not report it when it is not used', () =>
       testScript('other-bin').should.deepEqual([]));
@@ -35,7 +34,7 @@ describe('bin special parser', () => {
       testScript(false).should.deepEqual([]));
 
     it('should ignore the dependencies without bin entry', () =>
-      testScript('no-bin', ['nobin']).should.deepEqual([]));
+      testScript('no-binary', ['eslint-config-standard']).should.deepEqual([]));
   }
 
   describe('on `package.json`', () => {

--- a/test/special/bin.js
+++ b/test/special/bin.js
@@ -29,6 +29,18 @@ const testCases = [
     expected: ['binary-package'],
   },
   {
+    name: 'detect package bin without prefix dot',
+    script: 'node_modules/.bin/binary-entry',
+    dependencies: ['binary-package'],
+    expected: ['binary-package'],
+  },
+  {
+    name: 'detect package path without prefix dot',
+    script: 'node_modules/binary-package/bin/binary-exe',
+    dependencies: ['binary-package'],
+    expected: ['binary-package'],
+  },
+  {
     name: 'not report it when it is not used',
     script: 'other-binary-entry',
     dependencies: ['binary-package'],

--- a/test/special/bin.js
+++ b/test/special/bin.js
@@ -41,6 +41,12 @@ const testCases = [
     expected: ['binary-package'],
   },
   {
+    name: 'detect binary call with variable set',
+    script: 'NODE_ENV=production binary-entry',
+    dependencies: ['binary-package'],
+    expected: ['binary-package'],
+  },
+  {
     name: 'not report it when it is not used',
     script: 'other-binary-entry',
     dependencies: ['binary-package'],

--- a/test/special/bin.js
+++ b/test/special/bin.js
@@ -23,6 +23,12 @@ const testCases = [
     expected: ['binary-package'],
   },
   {
+    name: 'detect packages combined with `npm bin` command',
+    script: '$(npm bin)/binary-entry',
+    dependencies: ['binary-package'],
+    expected: ['binary-package'],
+  },
+  {
     name: 'not report it when it is not used',
     script: 'other-binary-entry',
     dependencies: ['binary-package'],

--- a/test/special/node_modules/binary-package/package.json
+++ b/test/special/node_modules/binary-package/package.json
@@ -1,0 +1,5 @@
+{
+  "bin": {
+    "binary-entry": "./bin/binary-exe"
+  }
+}


### PR DESCRIPTION
- It supports `$(npm bin)/binary-entry` style command
- It supports command prefixed with environment variable set.
- Test cases are refactored to be data-driven + test helper pattern.
- Currently, the identification bases on space split word matching.