### PR TITLE
Improve detect Webpack loader function.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "codecov.io": "^0.1.6",
     "eslint": "^1.7.3",
     "eslint-config-airbnb": "^1.0.0",
+    "fs-promise": "^0.3.1",
     "isparta": "^4.0.0",
     "mocha": "^2.1.0",
     "should": "^7.1.0"

--- a/src/special/webpack.js
+++ b/src/special/webpack.js
@@ -1,5 +1,4 @@
 import path from 'path';
-import load from '../utils/load';
 
 function concat(array, item) {
   return array.concat(item);
@@ -46,7 +45,7 @@ function getLoaders(deps, loaders) {
 export default (content, filepath, deps) => {
   const filename = path.basename(filepath);
   if (filename === 'webpack.config.js') {
-    const module = load(content).module || {};
+    const module = require(filepath).module || {};
     const loaders = getLoaders(deps, module.loaders);
     const preLoaders = getLoaders(deps, module.preLoaders);
     const postLoaders = getLoaders(deps, module.postLoaders);

--- a/test/special/node_modules/webpack/index.js
+++ b/test/special/node_modules/webpack/index.js
@@ -1,0 +1,1 @@
+module.exports = 'webpack';

--- a/test/special/webpack.js
+++ b/test/special/webpack.js
@@ -1,8 +1,8 @@
 /* global describe, it */
 
 import 'should';
-import fs from 'fs';
 import path from 'path';
+import fsp from 'fs-promise';
 import parse from '../../src/special/webpack';
 
 const testCases = [
@@ -75,24 +75,24 @@ const testCases = [
   },
 ];
 
-function getTempPath(filename, content) {
+async function getTempPath(filename, content) {
   const tempFolder = path.resolve(__dirname, `temp-${Date.now()}`);
   const tempPath = path.resolve(tempFolder, filename);
-  fs.mkdirSync(tempFolder);
-  fs.writeFileSync(tempPath, content);
+  await fsp.mkdir(tempFolder);
+  await fsp.writeFile(tempPath, content);
   return tempPath;
 }
 
-function removeTempFile(filepath) {
+async function removeTempFile(filepath) {
   const fileFolder = path.dirname(filepath);
-  fs.unlinkSync(filepath);
-  fs.rmdirSync(fileFolder);
+  await fsp.unlink(filepath);
+  await fsp.rmdir(fileFolder);
 }
 
-function testWebpack(filename, content, deps, expectedDeps) {
-  const tempPath = getTempPath(filename, content);
+async function testWebpack(filename, content, deps, expectedDeps) {
+  const tempPath = await getTempPath(filename, content);
   const result = parse(content, tempPath, deps, __dirname);
-  removeTempFile(tempPath);
+  await removeTempFile(tempPath);
   Array.from(result).should.deepEqual(expectedDeps);
 }
 
@@ -106,19 +106,19 @@ describe('webpack special parser', () => {
     const config = JSON.stringify({ module: testCases[0].module });
     const content = `module.exports = ${config}`;
     const deps = testCases[0].deps.concat(['unused-loader']);
-    testWebpack('webpack.config.js', content, deps, testCases[0].deps);
+    return testWebpack('webpack.config.js', content, deps, testCases[0].deps);
   });
 
   it('should handle require call to other modules', () => {
     const config = JSON.stringify({ module: testCases[0].module });
     const content = `module.exports = ${config}\nrequire('webpack')`;
-    testWebpack('webpack.config.js', content, testCases[0].deps, testCases[0].deps);
+    return testWebpack('webpack.config.js', content, testCases[0].deps, testCases[0].deps);
   });
 
   testCases.forEach(testCase =>
     it(`should ${testCase.name} in configuration file`, () => {
       const config = JSON.stringify({ module: testCase.module });
       const content = `module.exports = ${config}`;
-      testWebpack('webpack.config.js', content, testCase.deps, testCase.deps);
+      return testWebpack('webpack.config.js', content, testCase.deps, testCase.deps);
     }));
 });


### PR DESCRIPTION
- Evaluate the `webpack.config.js` to retrieve the webpack loader. I think it is OK for evaluation because webpack can only *retrieve* information from environment, should not *modify* anything. The webpack config is somehow independent with its business logic code. It is safe to evaluate the webpack config file.
- It successfully detects the webpack loaders in [Redux example](https://github.com/rackt/redux/blob/master/examples/todomvc/webpack.config.js).
- Consider resolve #42 