### PR TITLE
Evaluate ESLint preset to get accurate dependencies.

### DIFF
--- a/src/special/bin.js
+++ b/src/special/bin.js
@@ -9,9 +9,17 @@ function toKeyValuePair(object) {
   return Object.keys(object).map(key => ({ key, value: object[key] }));
 }
 
+function loadMetadata(dep, dir) {
+  try {
+    const packagePath = path.resolve(dir, 'node_modules', dep, 'package.json');
+    return require(packagePath);
+  } catch (error) {
+    return {}; // ignore silently
+  }
+}
+
 function toMetadata(dep, dir) {
-  const packagePath = path.resolve(dir, 'node_modules', dep, 'package.json');
-  const metadata = require(packagePath);
+  const metadata = loadMetadata(dep, dir);
   const binaryLookup = metadata.bin || {};
   const binaries = toKeyValuePair(binaryLookup);
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -180,13 +180,13 @@ describe('depcheck command line', () => {
     }));
 
   it('should find dependencies with special parser', () =>
-    testCli(makeArgv('eslint_airbnb', {
+    testCli(makeArgv('eslint_config', {
       argv: ['--specials=eslint'],
     }))
     .then(({ logs, error, exitCode }) => {
       logs.should.have.length(2);
-      logs[0].should.equal('Unused Dependencies');
-      logs[1].should.containEql('eslint-airbnb-testing');
+      logs[0].should.equal('Unused devDependencies');
+      logs[1].should.containEql('eslint-config-unused');
 
       error.should.be.empty();
       exitCode.should.equal(-1);

--- a/test/fake_modules/eslint_airbnb/.eslintrc
+++ b/test/fake_modules/eslint_airbnb/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": "airbnb"
-}

--- a/test/fake_modules/eslint_airbnb/package.json
+++ b/test/fake_modules/eslint_airbnb/package.json
@@ -1,9 +1,0 @@
-{
-  "dependencies": {
-    "eslint-airbnb-testing": "0.0.1"
-  },
-  "devDependencies": {
-    "eslint-config-airbnb": "0.0.1",
-    "eslint-plugin-react": "0.0.1"
-  }
-}

--- a/test/fake_modules/eslint_config/.eslintrc
+++ b/test/fake_modules/eslint_config/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "preset"
+}

--- a/test/fake_modules/eslint_config/package.json
+++ b/test/fake_modules/eslint_config/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "eslint-config-preset": "0.0.1",
+    "eslint-config-unused": "0.0.1"
+  }
+}

--- a/test/special/bin.js
+++ b/test/special/bin.js
@@ -59,9 +59,15 @@ const testCases = [
     expected: [],
   },
   {
-    name: 'ignore the dependencies without bin entry',
+    name: 'ignore dependency without bin entry',
     script: 'binary-entry',
-    dependencies: ['eslint-config-standard'],
+    dependencies: ['binary-no-bin'],
+    expected: [],
+  },
+  {
+    name: 'handle dependency without package.json',
+    script: 'binary-entry',
+    dependencies: ['binary-no-package'],
     expected: [],
   },
 ];

--- a/test/special/eslint.js
+++ b/test/special/eslint.js
@@ -11,27 +11,43 @@ const testCases = [
     expected: [],
   },
   {
-    name: 'handle the `standard` config',
+    name: 'detect specific parser',
     content: {
-      extends: 'standard',
+      parser: 'babel-eslint',
     },
     expected: [
-      'eslint-config-standard',
-      'eslint-plugin-standard',
+      'babel-eslint',
     ],
   },
   {
-    name: 'handle the `airbnb` config',
+    name: 'detect specific plugins',
     content: {
-      extends: 'airbnb',
+      plugins: ['mocha'],
     },
     expected: [
-      'eslint-config-airbnb',
-      'eslint-plugin-react',
+      'eslint-plugin-mocha',
     ],
   },
   {
-    name: 'handle the `airbnb/base` config',
+    name: 'handle eslint config with short name',
+    content: {
+      extends: 'preset',
+    },
+    expected: [
+      'eslint-config-preset',
+    ],
+  },
+  {
+    name: 'handle eslint config with full name',
+    content: {
+      extends: 'eslint-config-preset',
+    },
+    expected: [
+      'eslint-config-preset',
+    ],
+  },
+  {
+    name: 'handle eslint config from package module',
     content: {
       extends: 'airbnb/base',
     },
@@ -40,12 +56,23 @@ const testCases = [
     ],
   },
   {
-    name: 'handle config with full name',
+    name: 'handle eslint config with undeclared plugins',
     content: {
-      extends: 'eslint-config-full-name',
+      extends: 'airbnb/react',
     },
     expected: [
-      'eslint-config-full-name',
+      'eslint-config-airbnb',
+      'eslint-plugin-react',
+    ],
+  },
+  {
+    name: 'handle eslint config with nested extends',
+    content: {
+      extends: 'airbnb',
+    },
+    expected: [
+      'eslint-config-airbnb',
+      'eslint-plugin-react',
     ],
   },
   {
@@ -68,33 +95,6 @@ const testCases = [
       extends: './config',
     },
     expected: [],
-  },
-  {
-    name: 'handle peer dependencies from relative path config',
-    content: {
-      extends: './node_modules/eslint-config-standard',
-    },
-    expected: [
-      'eslint-plugin-standard',
-    ],
-  },
-  {
-    name: 'detect specific parser',
-    content: {
-      parser: 'babel-eslint',
-    },
-    expected: [
-      'babel-eslint',
-    ],
-  },
-  {
-    name: 'detect specific plugins',
-    content: {
-      plugins: ['mocha'],
-    },
-    expected: [
-      'eslint-plugin-mocha',
-    ],
   },
 ];
 

--- a/test/special/node_modules/binary-no-bin/package.json
+++ b/test/special/node_modules/binary-no-bin/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "no-binary-entry"
+}

--- a/test/special/node_modules/binary-no-package/index.js
+++ b/test/special/node_modules/binary-no-package/index.js
@@ -1,0 +1,1 @@
+module.exports = 'export by index.js, without package.json';

--- a/test/special/node_modules/eslint-config-airbnb/base.js
+++ b/test/special/node_modules/eslint-config-airbnb/base.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/special/node_modules/eslint-config-airbnb/index.js
+++ b/test/special/node_modules/eslint-config-airbnb/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: [
+    'eslint-config-airbnb/base',
+    'eslint-config-airbnb/react',
+  ],
+};

--- a/test/special/node_modules/eslint-config-airbnb/react.js
+++ b/test/special/node_modules/eslint-config-airbnb/react.js
@@ -1,0 +1,5 @@
+module.exports = {
+  'plugins': [
+    'react',
+  ],
+};

--- a/test/special/node_modules/eslint-config-preset/index.js
+++ b/test/special/node_modules/eslint-config-preset/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/special/node_modules/eslint-config-standard/package.json
+++ b/test/special/node_modules/eslint-config-standard/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "eslint-config-standard",
-  "peerDependencies": {
-    "eslint-plugin-standard": "0.0.1"
-  }
-}

--- a/test/special/webpack.js
+++ b/test/special/webpack.js
@@ -75,8 +75,12 @@ const testCases = [
   },
 ];
 
+function random() {
+  return Math.random().toString().substring(2);
+}
+
 async function getTempPath(filename, content) {
-  const tempFolder = path.resolve(__dirname, `temp-${Date.now()}`);
+  const tempFolder = path.resolve(__dirname, `temp-${random()}`);
   const tempPath = path.resolve(tempFolder, filename);
   await fsp.mkdir(tempFolder);
   await fsp.writeFile(tempPath, content);


### PR DESCRIPTION
- Evaluate ESLint preset to get accurate dependencies.
- Update the ESLint special parser test spec.
- Resolve a bug about bin special parser. Safe handle no `package.json` case.
- Resolve a potential bug in webpack test code - use random string for temp folder name.