### PR TITLE
Detect dependencies in default mocha opts file.

### DIFF
--- a/src/special/mocha.js
+++ b/src/special/mocha.js
@@ -1,0 +1,15 @@
+import path from 'path';
+
+export default (content, filepath, deps, rootDir) => {
+  const defaultOptPath = path.resolve(rootDir, 'test/mocha.opts');
+  if (filepath === defaultOptPath) {
+    return content
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line.indexOf('--require') === 0)
+      .map(line => line.substring('--require'.length).trim())
+      .filter(name => deps.indexOf(name) !== -1);
+  }
+
+  return [];
+};

--- a/test/special/mocha.js
+++ b/test/special/mocha.js
@@ -1,0 +1,19 @@
+/* global describe, it */
+
+import 'should';
+import path from 'path';
+import parse from '../../src/special/mocha';
+
+describe('mocha special parser', () => {
+  it('should ignore when filename is not supported', () => {
+    const result = parse('content', 'not-supported.txt', [], __dirname);
+    result.should.deepEqual([]);
+  });
+
+  it('should recognize unused dependencies in default mocha options', () => {
+    const content = ['--require chai', '--ui bdd', '--reporter spec'].join('\n');
+    const optPath = path.resolve(__dirname, 'test/mocha.opts');
+    const result = parse(content, optPath, ['chai', 'unused'], __dirname);
+    result.should.deepEqual(['chai']);
+  });
+});


### PR DESCRIPTION
Related #76, support the first default opts file.