### PR TITLE
Implement missing dependencies feature

### DIFF
--- a/build/check-json.js
+++ b/build/check-json.js
@@ -1,4 +1,3 @@
-import path from 'path';
 import assert from 'assert';
 
 function readStdin() {
@@ -22,12 +21,12 @@ function readStdin() {
 }
 
 function check(result) {
-  const badJsFile = path.resolve(__dirname, '../test/fake_modules/bad_js/index.js');
   return new Promise(() => {
     assert.deepEqual(result.dependencies, []);
     assert.deepEqual(result.devDependencies, []);
+    assert.deepEqual(result.missing, []);
     assert.deepEqual(result.invalidDirs, {});
-    assert.deepEqual(Object.keys(result.invalidFiles), [badJsFile]);
+    assert.deepEqual(result.invalidFiles, {});
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "babylon": "^6.1.21",
+    "builtin-modules": "^1.1.1",
     "deps-regex": "^0.1.4",
     "js-yaml": "^3.4.2",
     "minimatch": "^3.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,15 @@ function isStringArray(obj) {
   return obj instanceof Array && obj.every(item => typeof item === 'string');
 }
 
+function isModule(dir) {
+  try {
+    require(path.resolve(dir, 'package.json'));
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
 function getDependencies(dir, filename, deps, parser, detectors) {
   const detect = node =>
     detectors.map(detector => safeDetect(detector, node)).reduce(concat, []);
@@ -152,8 +161,9 @@ function checkDirectory(dir, rootDir, ignoreDirs, deps, parsers, detectors) {
     const finder = walkdir(dir, { 'no_recurse': true });
 
     finder.on('directory', subdir =>
-      ignoreDirs.indexOf(path.basename(subdir)) === -1 &&
-      promises.push(checkDirectory(subdir, rootDir, ignoreDirs, deps, parsers, detectors)));
+      ignoreDirs.indexOf(path.basename(subdir)) === -1 && !isModule(subdir)
+      ? promises.push(checkDirectory(subdir, rootDir, ignoreDirs, deps, parsers, detectors))
+      : null);
 
     finder.on('file', filename =>
       promises.push(...checkFile(rootDir, filename, deps, parsers, detectors)));

--- a/src/utils/output.js
+++ b/src/utils/output.js
@@ -8,7 +8,8 @@ function replacer(key, value) {
 
 function noIssue(result) {
   return result.dependencies.length === 0
-      && result.devDependencies.length === 0;
+      && result.devDependencies.length === 0
+      && result.missing.length === 0;
 }
 
 function prettify(caption, deps) {
@@ -25,7 +26,8 @@ export default function output(result, log, json) {
     } else {
       const deps = prettify('Unused dependencies', result.dependencies);
       const devDeps = prettify('Unused devDependencies', result.devDependencies);
-      const content = deps.concat(devDeps).join('\n');
+      const missing = prettify('Missing dependencies', result.missing);
+      const content = deps.concat(devDeps, missing).join('\n');
 
       log(content);
     }

--- a/src/utils/output.js
+++ b/src/utils/output.js
@@ -6,7 +6,7 @@ function replacer(key, value) {
   return value;
 }
 
-function noUnused(result) {
+function noIssue(result) {
   return result.dependencies.length === 0
       && result.devDependencies.length === 0;
 }
@@ -20,11 +20,11 @@ export default function output(result, log, json) {
   return new Promise(resolve => {
     if (json) {
       log(JSON.stringify(result, replacer));
-    } else if (noUnused(result)) {
-      log('No unused dependencies');
+    } else if (noIssue(result)) {
+      log('No depcheck issue');
     } else {
-      const deps = prettify('Unused Dependencies', result.dependencies);
-      const devDeps = prettify('\nUnused devDependencies', result.devDependencies);
+      const deps = prettify('Unused dependencies', result.dependencies);
+      const devDeps = prettify('Unused devDependencies', result.devDependencies);
       const content = deps.concat(devDeps).join('\n');
 
       log(content);

--- a/test/cli.js
+++ b/test/cli.js
@@ -161,7 +161,7 @@ describe('depcheck command line', () => {
     .then(({ logs, error, exitCode }) => {
       logs.should.have.length(2);
       logs[0].should.equal('Unused devDependencies');
-      logs[1].should.containEql('mocha');
+      logs[1].should.containEql('unused-dev-dep');
 
       error.should.be.empty();
       exitCode.should.equal(-1);

--- a/test/cli.js
+++ b/test/cli.js
@@ -69,6 +69,7 @@ describe('depcheck command line', () => {
 
         actual.dependencies.should.eql(expected.dependencies);
         actual.devDependencies.should.eql(expected.devDependencies);
+        actual.missing.should.eql(expected.missing);
 
         error.should.be.empty();
         exitCode.should.equal(0); // JSON output always return 0

--- a/test/cli.js
+++ b/test/cli.js
@@ -137,10 +137,10 @@ describe('depcheck command line', () => {
       exitCode.should.equal(0);
     }));
 
-  it('should output no unused dependencies when happen', () =>
+  it('should output no depcheck issue when happen', () =>
     testCli([path.resolve(__dirname, './fake_modules/good')])
     .then(({ log, error, exitCode }) => {
-      log.should.equal('No unused dependencies');
+      log.should.equal('No depcheck issue');
       error.should.be.empty();
       exitCode.should.equal(0);
     }));
@@ -149,7 +149,7 @@ describe('depcheck command line', () => {
     testCli(makeArgv('bad', {}))
     .then(({ logs, error, exitCode }) => {
       logs.should.have.length(2);
-      logs[0].should.equal('Unused Dependencies');
+      logs[0].should.equal('Unused dependencies');
       logs[1].should.containEql('optimist');
 
       error.should.be.empty();
@@ -173,7 +173,7 @@ describe('depcheck command line', () => {
     }))
     .then(({ logs, error, exitCode }) => {
       logs.should.have.length(2);
-      logs[0].should.equal('Unused Dependencies');
+      logs[0].should.equal('Unused dependencies');
       logs[1].should.containEql('react');
 
       error.should.be.empty();
@@ -186,7 +186,7 @@ describe('depcheck command line', () => {
     }))
     .then(({ logs, error, exitCode }) => {
       logs.should.have.length(2);
-      logs[0].should.equal('Unused Dependencies');
+      logs[0].should.equal('Unused dependencies');
       logs[1].should.containEql('react');
 
       error.should.be.empty();
@@ -199,7 +199,7 @@ describe('depcheck command line', () => {
     }))
     .then(({ logs, error, exitCode }) => {
       logs.should.have.length(2);
-      logs[0].should.equal('Unused Dependencies');
+      logs[0].should.equal('Unused dependencies');
       logs[1].should.containEql('react');
 
       error.should.be.empty();

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -22,8 +22,8 @@ function testE2E(module, output) {
 
 describe('depcheck end-to-end', () => {
   it('should find all dependencies', () =>
-    testE2E('good', ['No unused dependencies']));
+    testE2E('good', ['No depcheck issue']));
 
   it('should find unused dependencies', () =>
-    testE2E('bad', ['Unused Dependencies', '* optimist']));
+    testE2E('bad', ['Unused dependencies', '* optimist']));
 });

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -26,4 +26,7 @@ describe('depcheck end-to-end', () => {
 
   it('should find unused dependencies', () =>
     testE2E('bad', ['Unused dependencies', '* optimist']));
+
+  it('should find missing dependencies', () =>
+    testE2E('missing', ['Missing dependencies', '* missing-dep']));
 });

--- a/test/fake_modules/bad_es6/package.json
+++ b/test/fake_modules/bad_es6/package.json
@@ -2,5 +2,16 @@
   "dependencies": {
     "dont-find-me": "~0.0.1",
     "find-me": "^0.1.0"
+  },
+  "devDependencies": {
+    "name-import": "1.2.3",
+    "star-import": "1.2.3",
+    "member-import": "1.2.3",
+    "member-alias-import": "1.2.3",
+    "multiple-member-import": "1.2.3",
+    "mixed-member-alias-import": "1.2.3",
+    "mixed-name-memeber-import": "1.2.3",
+    "mixed-default-star-import": "1.2.3",
+    "default-member-import": "1.2.3"
   }
 }

--- a/test/fake_modules/dev/index.js
+++ b/test/fake_modules/dev/index.js
@@ -1,3 +1,1 @@
-/* eslint-disable no-unused-vars */
-
-const optimist = require('optimist');
+require('used-dep');

--- a/test/fake_modules/dev/package.json
+++ b/test/fake_modules/dev/package.json
@@ -1,6 +1,8 @@
 {
-  "dependencies": {},
+  "dependencies": {
+    "used-dep": "0.0.1"
+  },
   "devDependencies": {
-    "mocha": "~1.8.1"
+    "unused-dev-dep": "~1.8.1"
   }
 }

--- a/test/fake_modules/missing/index.js
+++ b/test/fake_modules/missing/index.js
@@ -1,0 +1,4 @@
+require('missing-dep');
+require('fs'); // recognize node.js built-in module
+require(1); // ignore require number call
+require(); // ignore require call with no arguments

--- a/test/fake_modules/missing/package.json
+++ b/test/fake_modules/missing/package.json
@@ -1,0 +1,4 @@
+{
+  "dependencies": {
+  }
+}

--- a/test/fake_modules/missing_nested/index.js
+++ b/test/fake_modules/missing_nested/index.js
@@ -1,0 +1,2 @@
+require('used-dep');
+require('outer-missing-dep');

--- a/test/fake_modules/missing_nested/nested/index.js
+++ b/test/fake_modules/missing_nested/nested/index.js
@@ -1,0 +1,1 @@
+require('nested-missing-dep'); // missing dep in nested module is ignored

--- a/test/fake_modules/missing_nested/nested/package.json
+++ b/test/fake_modules/missing_nested/nested/package.json
@@ -1,0 +1,4 @@
+{
+  "dependencies": {
+  }
+}

--- a/test/fake_modules/missing_nested/package.json
+++ b/test/fake_modules/missing_nested/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "used-dep": "1.2.3"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -37,6 +37,7 @@ describe('depcheck', () => {
         const expected = testCase.expected;
         result.dependencies.should.eql(expected.dependencies);
         result.devDependencies.should.eql(expected.devDependencies);
+        result.missing.should.eql(expected.missing);
       }));
   });
 

--- a/test/spec.json
+++ b/test/spec.json
@@ -14,7 +14,6 @@
     "name": "find unused dependencies in ES6 files",
     "module": "bad_es6",
     "options": {
-      "withoutDev": true
     },
     "expected": {
       "dependencies": ["dont-find-me"],
@@ -85,7 +84,7 @@
     },
     "expected": {
       "dependencies": [],
-      "devDependencies": ["mocha"]
+      "devDependencies": ["unused-dev-dep"]
     }
   },
   {

--- a/test/spec.json
+++ b/test/spec.json
@@ -7,7 +7,8 @@
     },
     "expected": {
       "dependencies": ["optimist"],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -17,7 +18,8 @@
     },
     "expected": {
       "dependencies": ["dont-find-me"],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -28,7 +30,8 @@
     },
     "expected": {
       "dependencies": [],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -39,7 +42,8 @@
     },
     "expected": {
       "dependencies": ["unsupported-syntax"],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     },
     "notice": "See `good_es6/index.js` file for more information on the unsupported ES6 import syntax, which we assert here as the expected missing import."
   },
@@ -51,7 +55,19 @@
     },
     "expected": {
       "dependencies": [],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
+    }
+  },
+  {
+    "name": "find dependencies used in code but not declared in package.json",
+    "module": "missing",
+    "options": {
+    },
+    "expected": {
+      "dependencies": [],
+      "devDependencies": [],
+      "missing": ["missing-dep"]
     }
   },
   {
@@ -62,7 +78,8 @@
     },
     "expected": {
       "dependencies": [],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -73,7 +90,8 @@
     },
     "expected": {
       "dependencies": [],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -84,7 +102,8 @@
     },
     "expected": {
       "dependencies": [],
-      "devDependencies": ["unused-dev-dep"]
+      "devDependencies": ["unused-dev-dep"],
+      "missing": []
     }
   },
   {
@@ -94,7 +113,8 @@
     },
     "expected": {
       "dependencies": ["unused-dep"],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -104,7 +124,8 @@
     },
     "expected": {
       "dependencies": ["unused-nested-dep"],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -114,7 +135,8 @@
     },
     "expected": {
       "dependencies": ["unused-dep"],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -124,7 +146,8 @@
     },
     "expected": {
       "dependencies": [],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -134,7 +157,8 @@
     },
     "expected": {
       "dependencies": ["empty-package"],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -144,7 +168,8 @@
     },
     "expected": {
       "dependencies": ["shebang"],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -154,7 +179,8 @@
     },
     "expected": {
       "dependencies": [],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -165,7 +191,8 @@
     },
     "expected": {
       "dependencies": [],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -176,7 +203,8 @@
     },
     "expected": {
       "dependencies": ["anybin"],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -187,7 +215,8 @@
     },
     "expected": {
       "dependencies": [],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -198,7 +227,8 @@
     },
     "expected": {
       "dependencies": ["anybin"],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -208,7 +238,8 @@
     },
     "expected": {
       "dependencies": ["require-nothing"],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -218,7 +249,8 @@
     },
     "expected": {
       "dependencies": [],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -229,7 +261,8 @@
     },
     "expected": {
       "dependencies": ["module_bad_deep"],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -240,7 +273,8 @@
     },
     "expected": {
       "dependencies": [],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -250,7 +284,8 @@
     },
     "expected": {
       "dependencies": [],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -260,7 +295,8 @@
     },
     "expected": {
       "dependencies": [],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -270,7 +306,8 @@
     },
     "expected": {
       "dependencies": ["coffee"],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -280,7 +317,8 @@
     },
     "expected": {
       "dependencies": ["@unused/package"],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   },
   {
@@ -290,7 +328,8 @@
     },
     "expected": {
       "dependencies": ["number"],
-      "devDependencies": []
+      "devDependencies": [],
+      "missing": []
     }
   }
 ]

--- a/test/spec.json
+++ b/test/spec.json
@@ -71,6 +71,17 @@
     }
   },
   {
+    "name": "ignore the missing dependencies in nested module",
+    "module": "missing_nested",
+    "options": {
+    },
+    "expected": {
+      "dependencies": [],
+      "devDependencies": [],
+      "missing": ["outer-missing-dep"]
+    }
+  },
+  {
     "name": "find grunt dependencies",
     "module": "grunt",
     "options": {


### PR DESCRIPTION
Resolve #41 #83 

- ~~**Known bug**: dependencies from nested folder project is marked as missing.~~ (See breaking change)
- **Breaking change**: depcheck will stop go into a folder containing `package.json` file. Such folder is considered as another module and should set up with another depcheck.
- Test cases are updated.