### PR TITLE
Implement the dependencies used in mocha opts

### DIFF
--- a/src/component.json
+++ b/src/component.json
@@ -12,6 +12,7 @@
     "requireCallExpression"
   ],
   "special": [
-    "eslint"
+    "eslint",
+    "mocha"
   ]
 }

--- a/src/special/mocha.js
+++ b/src/special/mocha.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import requirePackageName from 'require-package-name';
 import getScripts from '../utils/get-scripts';
 
 function concat(result, array) {
@@ -18,6 +19,7 @@ function getRequires(content, deps) {
     .map(line => line.trim())
     .filter(line => line.indexOf('--require ') === 0)
     .map(line => line.substring('--require '.length).trim())
+    .map(requirePackageName)
     .filter(name => deps.indexOf(name) !== -1);
 }
 

--- a/src/special/mocha.js
+++ b/src/special/mocha.js
@@ -1,15 +1,41 @@
+import fs from 'fs';
 import path from 'path';
+import getScripts from '../utils/get-scripts';
+
+function concat(result, array) {
+  return result.concat(array);
+}
+
+function getOpts(script) {
+  const argvs = script.split(' ').filter(argv => argv);
+  const optsIndex = argvs.indexOf('--opts');
+  return optsIndex !== -1 ? argvs[optsIndex + 1] : null;
+}
+
+function getRequires(content, deps) {
+  return content
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.indexOf('--require ') === 0)
+    .map(line => line.substring('--require '.length).trim())
+    .filter(name => deps.indexOf(name) !== -1);
+}
 
 export default (content, filepath, deps, rootDir) => {
   const defaultOptPath = path.resolve(rootDir, 'test/mocha.opts');
   if (filepath === defaultOptPath) {
-    return content
-      .split('\n')
-      .map(line => line.trim())
-      .filter(line => line.indexOf('--require') === 0)
-      .map(line => line.substring('--require'.length).trim())
-      .filter(name => deps.indexOf(name) !== -1);
+    return getRequires(content, deps);
   }
 
-  return [];
+  // get mocha.opts from scripts
+  const requires = getScripts(filepath, content)
+    .filter(script => script.indexOf('mocha') !== -1)
+    .map(script => getOpts(script))
+    .filter(opts => opts)
+    .map(opts => path.resolve(filepath, '..', opts))
+    .map(optPath => fs.readFileSync(optPath, 'utf-8')) // TODO async read file
+    .map(optContent => getRequires(optContent, deps))
+    .reduce(concat, []);
+
+  return requires;
 };

--- a/src/utils/get-scripts.js
+++ b/src/utils/get-scripts.js
@@ -23,7 +23,6 @@ const travisCommands = [
   'script',
   'after_success or after_failure',
   'before_deploy',
-  'deploy',
   'after_deploy',
   'after_script',
 ];

--- a/test/fake_modules/mocha_opts/mocha.opts.txt
+++ b/test/fake_modules/mocha_opts/mocha.opts.txt
@@ -1,0 +1,4 @@
+--require babel
+--require chai
+--reporter dot
+--ui bdd

--- a/test/fake_modules/mocha_opts/package.json
+++ b/test/fake_modules/mocha_opts/package.json
@@ -1,0 +1,10 @@
+{
+  "devDependencies": {
+    "babel": "1.0.0",
+    "chai": "1.0.0",
+    "mocha": "1.0.0"
+  },
+  "scripts": {
+    "test": "mocha --opts mocha.opts.txt"
+  }
+}

--- a/test/spec.js
+++ b/test/spec.js
@@ -447,4 +447,19 @@ export default [
       using: {},
     },
   },
+  {
+    name: 'discover dependencies from mocha opts specified by scripts',
+    module: 'mocha_opts',
+    options: {
+    },
+    expected: {
+      dependencies: [],
+      devDependencies: ['mocha'],
+      missing: {},
+      using: {
+        babel: ['package.json'],
+        chai: ['package.json'],
+      },
+    },
+  },
 ];

--- a/test/special/mocha.js
+++ b/test/special/mocha.js
@@ -1,6 +1,7 @@
 /* global describe, it */
 
 import 'should';
+import fs from 'fs';
 import path from 'path';
 import parse from '../../src/special/mocha';
 
@@ -15,5 +16,14 @@ describe('mocha special parser', () => {
     const optPath = path.resolve(__dirname, 'test/mocha.opts');
     const result = parse(content, optPath, ['chai', 'unused'], __dirname);
     result.should.deepEqual(['chai']);
+  });
+
+  it('should recognize mocha options specified from scripts', () => {
+    const rootDir = path.resolve(__dirname, '../fake_modules/mocha_opts');
+    const packagePath = path.resolve(rootDir, 'package.json');
+    const packageContent = fs.readFileSync(packagePath, 'utf-8');
+    const dependencies = Object.keys(JSON.parse(packageContent).devDependencies);
+    const result = parse(packageContent, packagePath, dependencies, rootDir);
+    result.should.deepEqual(['babel', 'chai']);
   });
 });

--- a/test/special/mocha.js
+++ b/test/special/mocha.js
@@ -11,8 +11,15 @@ describe('mocha special parser', () => {
     result.should.deepEqual([]);
   });
 
-  it('should recognize unused dependencies in default mocha options', () => {
+  it('should recognize dependencies used in default mocha options', () => {
     const content = ['--require chai', '--ui bdd', '--reporter spec'].join('\n');
+    const optPath = path.resolve(__dirname, 'test/mocha.opts');
+    const result = parse(content, optPath, ['chai', 'unused'], __dirname);
+    result.should.deepEqual(['chai']);
+  });
+
+  it('should recognize dependencies path-module used in mocha options', () => {
+    const content = ['--require chai/path/to/module', '--ui bdd', '--reporter spec'].join('\n');
     const optPath = path.resolve(__dirname, 'test/mocha.opts');
     const result = parse(content, optPath, ['chai', 'unused'], __dirname);
     result.should.deepEqual(['chai']);


### PR DESCRIPTION
- The mocha opts can be specified by scripts.
- Add test cases.
- Resolve #76 