### PR TITLE
Refactor getScript logic to a single file.

### DIFF
--- a/src/special/bin.js
+++ b/src/special/bin.js
@@ -1,26 +1,5 @@
 import path from 'path';
-import yaml from 'js-yaml';
-
-const travisCommands = [
-  // Reference: http://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle
-  'before_install',
-  'install',
-  'before_script',
-  'script',
-  'after_success or after_failure',
-  'before_deploy',
-  'deploy',
-  'after_deploy',
-  'after_script',
-];
-
-function concat(array, item) {
-  return array.concat(item);
-}
-
-function getObjectValues(object) {
-  return Object.keys(object).map(key => object[key]);
-}
+import getScripts from '../utils/get-scripts';
 
 function toKeyValuePair(object) {
   return Object.keys(object).map(key => ({ key, value: object[key] }));
@@ -72,14 +51,10 @@ function getUsedDeps(deps, scripts, dir) {
   .map(metadata => metadata.dep);
 }
 
-export default (content, filename, deps, dir) => {
-  const basename = path.basename(filename);
-  if (basename === 'package.json') {
-    const scripts = getObjectValues(JSON.parse(content).scripts || {});
-    return getUsedDeps(deps, scripts, dir);
-  } else if (basename === '.travis.yml') {
-    const metadata = yaml.safeLoad(content) || {};
-    const scripts = travisCommands.map(cmd => metadata[cmd] || []).reduce(concat, []);
+export default (content, filepath, deps, dir) => {
+  const basename = path.basename(filepath);
+  if (basename === 'package.json' || basename === '.travis.yml') {
+    const scripts = getScripts(filepath, content);
     return getUsedDeps(deps, scripts, dir);
   }
 

--- a/src/utils/get-scripts.js
+++ b/src/utils/get-scripts.js
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+const travisCommands = [
+  // Reference: http://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle
+  'before_install',
+  'install',
+  'before_script',
+  'script',
+  'after_success or after_failure',
+  'before_deploy',
+  'deploy',
+  'after_deploy',
+  'after_script',
+];
+
+function concat(array, item) {
+  return array.concat(item);
+}
+
+function getObjectValues(object) {
+  return Object.keys(object).map(key => object[key]);
+}
+
+export default function getScripts(filepath, content = null) {
+  const basename = path.basename(filepath);
+  const fileContent = content !== null ? content : fs.readFileSync(filepath, 'utf-8');
+
+  if (basename === 'package.json') {
+    return getObjectValues(JSON.parse(fileContent).scripts || {});
+  } else if (basename === '.travis.yml') {
+    const metadata = yaml.safeLoad(content) || {};
+    return travisCommands.map(cmd => metadata[cmd] || []).reduce(concat, []);
+  }
+
+  return [];
+}

--- a/test/special/bin.js
+++ b/test/special/bin.js
@@ -90,7 +90,7 @@ describe('bin special parser', () => {
           ? JSON.stringify({ scripts: { t: testCase.script } })
           : '{}';
 
-        testParser(testCase, content, '/path/to/package.json');
+        testParser(testCase, content, `/path/to/${testCase.name}/package.json`);
       })));
 
   describe('on `.travis.yml`', () =>
@@ -100,7 +100,7 @@ describe('bin special parser', () => {
           ? `script:\n  - ${testCase.script}`
           : '';
 
-        testParser(testCase, content, '/path/to/.travis.yml');
+        testParser(testCase, content, `/path/to/${testCase.name}/.travis.yml`);
       })));
 
   it('should check lifecycle commands in `.travis.yml` file', () => {


### PR DESCRIPTION
- Refactor getScript logic to a single file.
- Apply cache to improve performance.
- APIs are not affected.
- Some invalid failing test cases are resolved.