### PR TITLE
Account for io being async

### DIFF
--- a/bin/depcheck
+++ b/bin/depcheck
@@ -6,4 +6,9 @@ require('../dist/cli')(
   process.argv.slice(2),
   console.log,
   console.error,
-  process.exit);
+  function (code) {
+    // ensure all data is flushed before terminating the process
+    process.stdout.on('finish', function () {
+      process.exit(code);
+    });
+  });


### PR DESCRIPTION
If there are a lot of results, there is a chance of exiting this process before it is finished writing to the console.

Wait for stdout to be finished before exiting.