### PR TITLE
Fix the logic about calculate missing dependencies

### DIFF
--- a/src/check.js
+++ b/src/check.js
@@ -180,7 +180,7 @@ function checkDirectory(dir, rootDir, ignoreDirs, deps, parsers, detectors) {
   });
 }
 
-function buildResult(result, deps, devDeps) {
+function buildResult(result, deps, devDeps, peerDeps, optionalDeps) {
   const usingDepsLookup = lodash(result.using)
     // { f1:[d1,d2,d3], f2:[d2,d3,d4] }
     .toPairs()
@@ -198,7 +198,8 @@ function buildResult(result, deps, devDeps) {
     .value();
 
   const usingDeps = Object.keys(usingDepsLookup);
-  const missingDeps = lodash.difference(usingDeps, deps.concat(devDeps));
+  const allDeps = deps.concat(devDeps).concat(peerDeps).concat(optionalDeps);
+  const missingDeps = lodash.difference(usingDeps, allDeps);
 
   const missingDepsLookup = lodash(missingDeps)
     .map(missingDep => [missingDep, usingDepsLookup[missingDep]])
@@ -215,8 +216,17 @@ function buildResult(result, deps, devDeps) {
   };
 }
 
-export function check(rootDir, ignoreDirs, deps, devDeps, parsers, detectors) {
+export function check({
+  rootDir,
+  ignoreDirs,
+  deps,
+  devDeps,
+  peerDeps,
+  optionalDeps,
+  parsers,
+  detectors,
+}) {
   const allDeps = lodash.union(deps, devDeps);
   return checkDirectory(rootDir, rootDir, ignoreDirs, allDeps, parsers, detectors)
-    .then(result => buildResult(result, deps, devDeps));
+    .then(result => buildResult(result, deps, devDeps, peerDeps, optionalDeps));
 }

--- a/src/index.js
+++ b/src/index.js
@@ -51,10 +51,21 @@ export default function depcheck(rootDir, options, callback) {
   const metadata = options.package || require(path.join(rootDir, 'package.json'));
   const dependencies = metadata.dependencies || {};
   const devDependencies = !withoutDev && metadata.devDependencies ? metadata.devDependencies : {};
+  const peerDeps = Object.keys(metadata.peerDependencies || {});
+  const optionalDeps = Object.keys(metadata.optionalDependencies || {});
   const deps = filterDependencies(rootDir, ignoreBinPackage, ignoreMatches, dependencies);
   const devDeps = filterDependencies(rootDir, ignoreBinPackage, ignoreMatches, devDependencies);
 
-  return check(rootDir, ignoreDirs, deps, devDeps, parsers, detectors).then(callback);
+  return check({
+    rootDir,
+    ignoreDirs,
+    deps,
+    devDeps,
+    peerDeps,
+    optionalDeps,
+    parsers,
+    detectors,
+  }).then(callback);
 }
 
 depcheck.parser = availableParsers;

--- a/test/fake_modules/missing_peer_deps/index.js
+++ b/test/fake_modules/missing_peer_deps/index.js
@@ -1,0 +1,3 @@
+require('missing-this-dep');
+require('peer-dep');
+require('optional-dep');

--- a/test/fake_modules/missing_peer_deps/package.json
+++ b/test/fake_modules/missing_peer_deps/package.json
@@ -1,0 +1,8 @@
+{
+  "peerDependencies": {
+    "peer-dep": "0.0.1"
+  },
+  "optionalDependencies": {
+    "optional-dep": "0.0.1"
+  }
+}

--- a/test/spec.js
+++ b/test/spec.js
@@ -156,6 +156,24 @@ export default [
     },
   },
   {
+    name: 'not report peer and optional dependencies as missing',
+    module: 'missing_peer_deps',
+    options: {
+    },
+    expected: {
+      dependencies: [],
+      devDependencies: [],
+      missing: {
+        'missing-this-dep': ['index.js'],
+      },
+      using: {
+        'missing-this-dep': ['index.js'],
+        'peer-dep': ['index.js'],
+        'optional-dep': ['index.js'],
+      },
+    },
+  },
+  {
     name: 'find grunt dependencies',
     module: 'grunt',
     options: {


### PR DESCRIPTION
Resolve #115 

- Exclude the peer and optional dependencies when calculate missing dependencies.
