### PR TITLE
Deprecate the `dev` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ The `directory` argument is the root directory of your project (where the `packa
 
 All the arguments are optional:
 
-`--dev=[true|false]`: A flag indicates if depcheck looks at `devDependencies`. By default, it is `true`. It means, depcheck looks at both `dependencies` and `devDependencies`.
-
 `--ignore-bin-package=[true|false]`: A flag indicates if depcheck ignores the packages containing bin entry. The default value is `true`.
 
 `--json`: Output results to JSON. When not specified, depcheck outputs in human friendly format.
@@ -75,6 +73,12 @@ All the arguments are optional:
 
 `--parsers`, `--detectors` and `--specials`: These arguments are for advanced usage. They provide an easy way to customize the file parser and dependency detection. Check [the pluggable design document](https://github.com/depcheck/depcheck/blob/master/doc/pluggable-design.md) for more information.
 
+### Deprecated arguments
+
+The following arguments are deprecated and will be removed in next major version:
+
+`--dev=[true|false]`: *[DEPRECATED]* It leads a wrong result for missing dependencies when it is `false`. This option will be enforced to `true` in next major version. The corresponding API option `withoutDev` is deprecated too.
+
 ## API
 
 Similar options are provided to `depcheck` function for programming.
@@ -83,7 +87,7 @@ Similar options are provided to `depcheck` function for programming.
 import depcheck from 'depcheck';
 
 const options = {
-  withoutDev: false, // check against devDependencies
+  withoutDev: false, // [DEPRECATED] check against devDependencies
   ignoreBinPackage: false, // ignore the packages with bin entry
   ignoreDirs: [ // folder with these names will be ignored
     'sandbox',

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "babylon": "^6.1.21",
     "builtin-modules": "^1.1.1",
+    "deprecate": "^0.1.0",
     "deps-regex": "^0.1.4",
     "js-yaml": "^3.4.2",
     "lodash": "^4.5.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,6 +2,8 @@ import fs from 'fs';
 import path from 'path';
 import yargs from 'yargs';
 import lodash from 'lodash';
+import deprecate from 'deprecate';
+
 import depcheck from './index';
 import { version } from '../package.json';
 
@@ -60,6 +62,16 @@ function print(result, log, json) {
   return result;
 }
 
+function checkDeprecation(argv) {
+  if (argv.dev === false) {
+    deprecate(
+      'The option `dev` is deprecated. It leads a wrong result for missing dependencies' +
+      ' when it is `false`. This option will be removed and enforced to `true` in next' +
+      ' major version.'
+    );
+  }
+}
+
 export default function cli(args, log, error, exit) {
   const opt = yargs(args)
     .usage('Usage: $0 [DIRECTORY]')
@@ -71,7 +83,7 @@ export default function cli(args, log, error, exit) {
       dev: true,
       'ignore-bin-package': false,
     })
-    .describe('dev', 'Check on devDependecies')
+    .describe('dev', '[DEPRECATED] Check on devDependecies')
     .describe('ignore-bin-package', 'Ignore package with bin entry')
     .describe('json', 'Output results to JSON')
     .describe('ignores', 'Comma separated package list to ignore')
@@ -81,6 +93,8 @@ export default function cli(args, log, error, exit) {
     .describe('specials', 'Comma separated special parser list')
     .version('version', 'Show version number', version)
     .help('help', 'Show this help message');
+
+  checkDeprecation(opt.argv);
 
   const dir = opt.argv._[0] || '.';
   const rootDir = path.resolve(dir);


### PR DESCRIPTION
Resolve #114 

- Show deprecation hint if run in CLI. However, not show hint if run by API, we are not pollute the caller's console
- Update the documentation.