### PR TITLE
Remove the `dev` options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,6 @@ All the arguments are optional:
 
 `--parsers`, `--detectors` and `--specials`: These arguments are for advanced usage. They provide an easy way to customize the file parser and dependency detection. Check [the pluggable design document](https://github.com/depcheck/depcheck/blob/master/doc/pluggable-design.md) for more information.
 
-### Deprecated arguments
-
-The following arguments are deprecated and will be removed in next major version:
-
-`--dev=[true|false]`: *[DEPRECATED]* It leads a wrong result for missing dependencies when it is `false`. This option will be enforced to `true` in next major version. The corresponding API option `withoutDev` is deprecated too.
-
 ## API
 
 Similar options are provided to `depcheck` function for programming.
@@ -87,7 +81,6 @@ Similar options are provided to `depcheck` function for programming.
 import depcheck from 'depcheck';
 
 const options = {
-  withoutDev: false, // [DEPRECATED] check against devDependencies
   ignoreBinPackage: false, // ignore the packages with bin entry
   ignoreDirs: [ // folder with these names will be ignored
     'sandbox',

--- a/doc/pluggable-design.md
+++ b/doc/pluggable-design.md
@@ -140,7 +140,7 @@ var opts = {
 
 ### Implement Custom Detector
 
-Detector is a JavaScript function accepts an AST node and package dependencies (including devDependencies unless `withoutDev` option is `true`) and returns an array of dependency package names.
+Detector is a JavaScript function accepts an AST node and package dependencies (including devDependencies, optionalDependencies and peerDependencies) and returns an array of dependency package names.
 
 The following code snippet is the ES6 `import` declaration detector:
 
@@ -220,7 +220,7 @@ As seen from the code snippet, there are four parameters passed into the *specia
 
 - Content, same as normal parser, the file content.
 - FilePath, the file path, use `path.basename` to retrieve the file name.
-- Deps, an array containing the package dependencies (including devDependencies unless `withoutDev` option is `true`).
+- Deps, an array containing the package dependencies (including devDependencies, optionalDependencies and peerDependencies).
 - Dir, the checking root directory passed from API or CLI.
 
 Pay attention that, special parser will match **all** files, please do file path or file name matching **by yourself** and only parse content only when necessary. In regards to the returning value, both AST node or plain string array are OK as a normal parser.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "babylon": "^6.1.21",
     "builtin-modules": "^1.1.1",
-    "deprecate": "^0.1.0",
     "deps-regex": "^0.1.4",
     "js-yaml": "^3.4.2",
     "lodash": "^4.5.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,7 +2,6 @@ import fs from 'fs';
 import path from 'path';
 import yargs from 'yargs';
 import lodash from 'lodash';
-import deprecate from 'deprecate';
 
 import depcheck from './index';
 import { version } from '../package.json';
@@ -62,28 +61,15 @@ function print(result, log, json) {
   return result;
 }
 
-function checkDeprecation(argv) {
-  if (argv.dev === false) {
-    deprecate(
-      'The option `dev` is deprecated. It leads a wrong result for missing dependencies' +
-      ' when it is `false`. This option will be removed and enforced to `true` in next' +
-      ' major version.'
-    );
-  }
-}
-
 export default function cli(args, log, error, exit) {
   const opt = yargs(args)
     .usage('Usage: $0 [DIRECTORY]')
     .boolean([
-      'dev',
       'ignore-bin-package',
     ])
     .default({
-      dev: true,
       'ignore-bin-package': false,
     })
-    .describe('dev', '[DEPRECATED] Check on devDependecies')
     .describe('ignore-bin-package', 'Ignore package with bin entry')
     .describe('json', 'Output results to JSON')
     .describe('ignores', 'Comma separated package list to ignore')
@@ -94,8 +80,6 @@ export default function cli(args, log, error, exit) {
     .version('version', 'Show version number', version)
     .help('help', 'Show this help message');
 
-  checkDeprecation(opt.argv);
-
   const dir = opt.argv._[0] || '.';
   const rootDir = path.resolve(dir);
 
@@ -104,7 +88,6 @@ export default function cli(args, log, error, exit) {
       path.resolve(rootDir, 'package.json'),
       `Path ${dir} does not contain a package.json file`))
     .then(() => depcheck(rootDir, {
-      withoutDev: !opt.argv.dev,
       ignoreBinPackage: opt.argv.ignoreBinPackage,
       ignoreMatches: (opt.argv.ignores || '').split(','),
       ignoreDirs: (opt.argv.ignoreDirs || '').split(','),

--- a/src/constants.js
+++ b/src/constants.js
@@ -19,7 +19,6 @@ export const availableDetectors = constructComponent(component, 'detector');
 export const availableSpecials = constructComponent(component, 'special');
 
 export const defaultOptions = {
-  withoutDev: false,
   ignoreBinPackage: false,
   ignoreMatches: [
   ],

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,6 @@ export default function depcheck(rootDir, options, callback) {
   const getOption = key =>
     lodash.isUndefined(options[key]) ? defaultOptions[key] : options[key];
 
-  const withoutDev = getOption('withoutDev');
   const ignoreBinPackage = getOption('ignoreBinPackage');
   const ignoreMatches = getOption('ignoreMatches');
   const ignoreDirs = lodash.union(defaultOptions.ignoreDirs, options.ignoreDirs);
@@ -50,7 +49,7 @@ export default function depcheck(rootDir, options, callback) {
 
   const metadata = options.package || require(path.join(rootDir, 'package.json'));
   const dependencies = metadata.dependencies || {};
-  const devDependencies = !withoutDev && metadata.devDependencies ? metadata.devDependencies : {};
+  const devDependencies = metadata.devDependencies || {};
   const peerDeps = Object.keys(metadata.peerDependencies || {});
   const optionalDeps = Object.keys(metadata.optionalDependencies || {});
   const deps = filterDependencies(rootDir, ignoreBinPackage, ignoreMatches, dependencies);

--- a/test/cli.js
+++ b/test/cli.js
@@ -14,10 +14,6 @@ function makeArgv(module, options) {
     argv.push('--json');
   }
 
-  if (options.withoutDev) {
-    argv.push('--dev=false');
-  }
-
   if (typeof options.ignoreBinPackage !== 'undefined') {
     argv.push(`--ignore-bin-package=${options.ignoreBinPackage}`);
   }

--- a/test/spec.js
+++ b/test/spec.js
@@ -3,7 +3,6 @@ export default [
     name: 'find unused dependencies',
     module: 'bad',
     options: {
-      withoutDev: true,
     },
     expected: {
       dependencies: ['optimist'],
@@ -39,7 +38,6 @@ export default [
     name: 'find all dependencies',
     module: 'good',
     options: {
-      withoutDev: true,
     },
     expected: {
       dependencies: [],
@@ -56,7 +54,6 @@ export default [
     name: 'find all dependencies in ES6 files',
     module: 'good_es6',
     options: {
-      withoutDev: true,
     },
     expected: {
       dependencies: ['unsupported-syntax'],
@@ -80,7 +77,6 @@ export default [
     name: 'recognize experimental ES7 syntax enabled in Babel by default',
     module: 'good_es7',
     options: {
-      withoutDev: true,
     },
     expected: {
       dependencies: [],
@@ -177,7 +173,6 @@ export default [
     name: 'find grunt dependencies',
     module: 'grunt',
     options: {
-      withoutDev: true,
     },
     expected: {
       dependencies: [],
@@ -192,7 +187,6 @@ export default [
     name: 'find grunt task dependencies',
     module: 'grunt-tasks',
     options: {
-      withoutDev: true,
     },
     expected: {
       dependencies: [],
@@ -207,7 +201,6 @@ export default [
     name: 'find unused package in devDependencies',
     module: 'dev',
     options: {
-      withoutDev: false,
     },
     expected: {
       dependencies: [],


### PR DESCRIPTION
Resolve #117 

- Remove the `dev` option from code completedly.
- Clean it up in documentations (README and design doc)