### PR TITLE
Resolve arrow function ESLint warning violation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,4 @@
 {
   "parser": "babel-eslint",
-  "extends": "airbnb/base",
-  "rules": {
-    "no-confusing-arrow": [0]
-  }
+  "extends": "airbnb/base"
 }

--- a/src/check.js
+++ b/src/check.js
@@ -152,9 +152,9 @@ function checkDirectory(dir, rootDir, ignoreDirs, deps, parsers, detectors) {
     const finder = walkdir(dir, { no_recurse: true });
 
     finder.on('directory', subdir =>
-      ignoreDirs.indexOf(path.basename(subdir)) === -1 && !isModule(subdir)
-      ? promises.push(checkDirectory(subdir, rootDir, ignoreDirs, deps, parsers, detectors))
-      : null);
+      (ignoreDirs.indexOf(path.basename(subdir)) === -1 && !isModule(subdir)
+        ? promises.push(checkDirectory(subdir, rootDir, ignoreDirs, deps, parsers, detectors))
+        : null));
 
     finder.on('file', filename =>
       promises.push(...checkFile(rootDir, filename, deps, parsers, detectors)));

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,7 +9,8 @@ import { version } from '../package.json';
 
 function checkPathExist(dir, errorMessage) {
   return new Promise((resolve, reject) =>
-    fs.exists(dir, result => result ? resolve() : reject(errorMessage)));
+    fs.exists(dir, result =>
+      (result ? resolve() : reject(errorMessage))));
 }
 
 function getParsers(parsers) {
@@ -48,7 +49,7 @@ function prettify(caption, deps) {
 
 function print(result, log, json) {
   if (json) {
-    log(JSON.stringify(result, (key, value) => lodash.isError(value) ? value.stack : value));
+    log(JSON.stringify(result, (key, value) => (lodash.isError(value) ? value.stack : value)));
   } else if (noIssue(result)) {
     log('No depcheck issue');
   } else {

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ function filterDependencies(rootDir, ignoreBinPackage, ignoreMatches, dependenci
 
 export default function depcheck(rootDir, options, callback) {
   const getOption = key =>
-    lodash.isUndefined(options[key]) ? defaultOptions[key] : options[key];
+    (lodash.isUndefined(options[key]) ? defaultOptions[key] : options[key]);
 
   const withoutDev = getOption('withoutDev');
   const ignoreBinPackage = getOption('ignoreBinPackage');
@@ -44,7 +44,7 @@ export default function depcheck(rootDir, options, callback) {
 
   const detectors = getOption('detectors');
   const parsers = lodash(getOption('parsers'))
-    .mapValues(value => lodash.isArray(value) ? value : [value])
+    .mapValues(value => (lodash.isArray(value) ? value : [value]))
     .merge({ '*': getOption('specials') })
     .value();
 

--- a/src/special/babel.js
+++ b/src/special/babel.js
@@ -21,7 +21,7 @@ function contain(array, dep, prefix) {
   }
 
   // extract name if wrapping with options
-  const names = array.map(item => lodash.isString(item) ? item : item[0]);
+  const names = array.map(item => (lodash.isString(item) ? item : item[0]));
   if (names.indexOf(dep) !== -1) {
     return true;
   }

--- a/test/fake_detectors/dependCallExpression.js
+++ b/test/fake_detectors/dependCallExpression.js
@@ -1,7 +1,8 @@
-export default node =>
-  node.type === 'CallExpression' &&
-  node.callee &&
-  node.callee.type === 'Identifier' &&
-  node.callee.name === 'depend'
-  ? node.arguments.map(arg => arg.value)
-  : [];
+export default function parse(node) {
+  return node.type === 'CallExpression' &&
+    node.callee &&
+    node.callee.type === 'Identifier' &&
+    node.callee.name === 'depend'
+    ? node.arguments.map(arg => arg.value)
+    : [];
+}

--- a/test/index.js
+++ b/test/index.js
@@ -92,7 +92,7 @@ describe('depcheck', () => {
 
     after(done =>
       fs.chmod(unreadablePath, '0700', error =>
-        error ? done(error) : fs.rmdir(unreadablePath, done)));
+        (error ? done(error) : fs.rmdir(unreadablePath, done))));
   }
 
   describe('access unreadable directory', () =>
@@ -135,7 +135,7 @@ describe('depcheck', () => {
 
     after(done =>
       fs.chmod(unreadablePath, '0700', error =>
-        error ? done(error) : fs.unlink(unreadablePath, done)));
+        (error ? done(error) : fs.unlink(unreadablePath, done))));
   }
 
   describe('access unreadable file', () =>


### PR DESCRIPTION
- Re-enable no-confusing-arrow from Airbnb config.
- Resolve the violation warnings.