### PR TITLE
Support gulp plugins loaded by gulp-load-plugins.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
+    "babel-traverse": "^6.7.3",
     "babylon": "^6.1.21",
     "builtin-modules": "^1.1.1",
     "deprecate": "^0.1.0",

--- a/src/special/gulp-load-plugins.js
+++ b/src/special/gulp-load-plugins.js
@@ -150,9 +150,11 @@ function check(content, deps, path) {
 }
 
 export default function parseGulpPlugins(content, filePath, deps, rootDir) {
-  const gulpfilePath = resolve(rootDir, 'gulpfile.js');
   const resolvedPath = resolve(filePath);
-  if (resolvedPath !== gulpfilePath) {
+  if (
+    resolvedPath !== resolve(rootDir, 'gulpfile.js') &&
+    resolvedPath !== resolve(rootDir, 'gulpfile.babel.js')
+  ) {
     return [];
   }
 

--- a/src/special/gulp-load-plugins.js
+++ b/src/special/gulp-load-plugins.js
@@ -1,3 +1,127 @@
-export default function parse() {
+import { resolve } from 'path';
+import lodash from 'lodash';
+import traverse from 'babel-traverse';
+
+import esParser from '../parser/es7';
+import importDetector from '../detector/importDeclaration';
+import requireDetector from '../detector/requireCallExpression';
+
+/**
+ * Get the reference paths to the imported variable.
+ * @example With code `import loadPlugins from 'x'`, returns references to `loadPlugins` variable.
+ */
+function getImportReferences(path) {
+  // check if import the default exported value
+  const [importDefaultSpecifier] = path.get('specifiers');
+  if (!importDefaultSpecifier.isImportDefaultSpecifier()) {
+    return [];
+  }
+
+  // get the identifier path
+  const identifier = importDefaultSpecifier.get('local');
+  if (!identifier.isIdentifier()) {
+    return [];
+  }
+
+  const variableName = identifier.node.name;
+  const bindings = path.scope.getBinding(variableName);
+  const references = bindings.referencePaths;
+
+  return references;
+}
+
+/**
+ * Get all the reference paths to the assigned variable.
+ * @example With code `$=loadPlugins()`, returns references to `$` variable.
+ */
+function getIdentifierReferences(path) {
+  if (
+    path.isIdentifier() &&
+    path.parentPath.isCallExpression() &&
+    path.parentPath.parentPath.isVariableDeclarator()
+  ) {
+    const idName = path.parentPath.parentPath.node.id.name;
+    const binding = path.scope.getBinding(idName);
+    const references = binding.referencePaths;
+
+    return references;
+  }
+
   return [];
+}
+
+/**
+ * Find the comprehensive member expression for the identifier variableName.
+ * @example With code `$.call.a.function()`, returns `$.call.a.function` string.
+ */
+function findMemberExpression(path) {
+  if (!path.isIdentifier()) {
+    return '';
+  }
+
+  const expression = findMemberExpression.recurse(path);
+  return expression;
+}
+
+findMemberExpression.recurse = (path) =>
+  (!path.parentPath.isMemberExpression()
+    ? path
+    : findMemberExpression.recurse(path.parentPath));
+
+/**
+ * Convert the gulp plugin call to corresponding npm package names
+ * @example With string `$.that.plugin`, returns `@that/gulp-plugin` as package name.
+ */
+function convertToPackageName(code) {
+  const parts = code.split('.');
+  if (parts.length === 2) { // $.jshint
+    // TODO do it later
+  } else if (parts.length === 3) { // $.scope.plugin
+    const scope = parts[1];
+    const name = lodash.kebabCase(parts[2]);
+    return `@${scope}/gulp-${name}`; // TODO logic not right
+  }
+
+  return '';
+}
+
+export default function parseGulpPlugins(content, filePath, deps, rootDir) {
+  const gulpfilePath = resolve(rootDir, 'gulpfile.js');
+  const resolvedPath = resolve(filePath);
+  if (resolvedPath !== gulpfilePath) {
+    return [];
+  }
+
+  const ast = esParser(content);
+  const results = [];
+
+  traverse(ast, {
+    enter(path) {
+      const [importPackage] = importDetector(path.node);
+      const [requirePackage] = requireDetector(path.node);
+
+      // check if import from 'gulp-load-plugins'
+      if (importPackage === 'gulp-load-plugins') {
+        const importReferences = getImportReferences(path);
+        const identifierReferences = lodash(importReferences)
+          .map(getIdentifierReferences)
+          .flatten()
+          .value();
+
+        identifierReferences.forEach(reference => {
+          const memberExpression = findMemberExpression(reference);
+          const code = content.slice(memberExpression.node.start, memberExpression.node.end);
+          const packageName = convertToPackageName(code);
+          results.push(packageName);
+        });
+      }
+
+      // check if require gulp-load-plugins package
+      if (requirePackage === 'gulp-load-plugins') {
+        // TODO implement
+      }
+    },
+  });
+
+  return lodash(results).filter(name => name).uniq().value();
 }

--- a/src/special/gulp-load-plugins.js
+++ b/src/special/gulp-load-plugins.js
@@ -1,0 +1,3 @@
+export default function parse() {
+  return [];
+}

--- a/src/special/gulp-load-plugins.js
+++ b/src/special/gulp-load-plugins.js
@@ -7,10 +7,10 @@ import importDetector from '../detector/importDeclaration';
 import requireDetector from '../detector/requireCallExpression';
 
 /**
- * Get the reference paths to the imported variable.
- * @example With code `import loadPlugins from 'x'`, returns references to `loadPlugins` variable.
+ * Get the variable name for the imported package.
+ * @example With code `import loadPlugins from 'x'`, returns the 'loadPlugins' string.
  */
-function getImportReferences(path) {
+function getImportVariableName(path) {
   // check if import the default exported value
   const [importDefaultSpecifier] = path.get('specifiers');
   if (!importDefaultSpecifier.isImportDefaultSpecifier()) {
@@ -24,6 +24,14 @@ function getImportReferences(path) {
   }
 
   const variableName = identifier.node.name;
+  return variableName;
+}
+
+/**
+ * Get the references to the variable in the path scope.
+ * @example Within the path scope, returns references to `loadPlugins` variable.
+ */
+function getReferences(path, variableName) {
   const bindings = path.scope.getBinding(variableName);
   const references = bindings.referencePaths;
 
@@ -72,10 +80,13 @@ findMemberExpression.recurse = (path) =>
  * Convert the gulp plugin call to corresponding npm package names
  * @example With string `$.that.plugin`, returns `@that/gulp-plugin` as package name.
  */
-function convertToPackageName(code) {
+function convertToPackageName(code, deps) {
   const parts = code.split('.');
   if (parts.length === 2) { // $.jshint
-    // TODO do it later
+    const name = lodash.kebabCase(parts[1]);
+    const candidates = [`gulp-${name}`, `gulp.${name}`];
+    const dep = lodash.intersection(candidates, deps)[0];
+    return dep;
   } else if (parts.length === 3) { // $.scope.plugin
     const scope = parts[1];
     const name = lodash.kebabCase(parts[2]);
@@ -102,7 +113,8 @@ export default function parseGulpPlugins(content, filePath, deps, rootDir) {
 
       // check if import from 'gulp-load-plugins'
       if (importPackage === 'gulp-load-plugins') {
-        const importReferences = getImportReferences(path);
+        const importVariableName = getImportVariableName(path);
+        const importReferences = getReferences(path, importVariableName);
         const identifierReferences = lodash(importReferences)
           .map(getIdentifierReferences)
           .flatten()
@@ -111,14 +123,65 @@ export default function parseGulpPlugins(content, filePath, deps, rootDir) {
         identifierReferences.forEach(reference => {
           const memberExpression = findMemberExpression(reference);
           const code = content.slice(memberExpression.node.start, memberExpression.node.end);
-          const packageName = convertToPackageName(code);
+          const packageName = convertToPackageName(code, deps);
           results.push(packageName);
         });
       }
 
       // check if require gulp-load-plugins package
       if (requirePackage === 'gulp-load-plugins') {
-        // TODO implement
+        if (
+          path.parentPath.isVariableDeclarator() &&
+          path.parentPath.get('id').isIdentifier()
+        ) {
+          // Pattern: const plugins = require('gulp-load-plugins')
+          const requireVariableName = path.parentPath.get('id').node.name;
+          const requireReferences = getReferences(path, requireVariableName);
+
+          // TODO the following code is copied from import part. Refactor the code.
+          const identifierReferences = lodash(requireReferences)
+            .map(getIdentifierReferences)
+            .flatten()
+            .value();
+
+          identifierReferences.forEach(reference => {
+            const memberExpression = findMemberExpression(reference);
+            const code = content.slice(memberExpression.node.start, memberExpression.node.end);
+            const packageName = convertToPackageName(code, deps);
+            results.push(packageName);
+          });
+        } else if (
+          path.parentPath.isCallExpression() &&
+          path.parentPath.parentPath.isVariableDeclarator() &&
+          path.parentPath.parentPath.get('id').isIdentifier()
+        ) {
+          // Pattern: const $ = require('gulp-load-plugins')()
+          const requireVariableName = path.parentPath.parentPath.get('id').node.name;
+
+          // TODO copy from getIdentifierReferences, may avoid duplicate.
+          const binding = path.scope.getBinding(requireVariableName);
+          const identifierReferences = binding.referencePaths;
+
+          // TODO refactor to avoid duplicate.
+          identifierReferences.forEach(reference => {
+            const memberExpression = findMemberExpression(reference);
+            const code = content.slice(memberExpression.node.start, memberExpression.node.end);
+            const packageName = convertToPackageName(code, deps);
+            results.push(packageName);
+          });
+        } else if (
+          path.parentPath.isCallExpression() &&
+          path.parentPath.parentPath.isMemberExpression()
+        ) {
+          // Pattern: require('gulp-load-plugins')().thisPlugin()
+          const identifierExpression = path.parentPath;
+          const memberExpression = path.parentPath.parentPath;
+
+          // Skip the `require('gulp-load-plugins')()` blob.
+          const code = content.slice(identifierExpression.node.end, memberExpression.node.end);
+          const packageName = convertToPackageName(code, deps);
+          results.push(packageName);
+        }
       }
     },
   });

--- a/test/special/gulp-load-plugins.js
+++ b/test/special/gulp-load-plugins.js
@@ -39,6 +39,13 @@ describe('gulp-load-plugins special parser', () => {
         $.scope.plugin();
       `,
     },
+    'dependency used in direct call': {
+      dependency: 'gulp-sourcemaps',
+      code: `
+        const $ = require('gulp-load-plugins')();
+        $.sourcemaps.init();
+      `,
+    },
   };
 
   ['gulpfile.js', 'gulpfile.babel.js'].forEach(gulpFileName =>

--- a/test/special/gulp-load-plugins.js
+++ b/test/special/gulp-load-plugins.js
@@ -41,16 +41,17 @@ describe('gulp-load-plugins special parser', () => {
     },
   };
 
-  Object.keys(testCases).forEach(name =>
-    it(`should recognize ${name}`, () => {
-      const testCase = testCases[name];
-      const result = parse(
-        testCase.code,
-        '/path/to/gulpfile.js',
-        [testCase.dependency, 'gulp-load-plugins'],
-        '/path/to'
-      );
+  ['gulpfile.js', 'gulpfile.babel.js'].forEach(gulpFileName =>
+    Object.keys(testCases).forEach(name =>
+      it(`should recognize ${name}`, () => {
+        const testCase = testCases[name];
+        const result = parse(
+          testCase.code,
+          `/path/to/${gulpFileName}`,
+          [testCase.dependency, 'gulp-load-plugins'],
+          '/path/to'
+        );
 
-      result.should.deepEqual([testCase.dependency]);
-    }));
+        result.should.deepEqual([testCase.dependency]);
+      })));
 });

--- a/test/special/gulp-load-plugins.js
+++ b/test/special/gulp-load-plugins.js
@@ -1,0 +1,56 @@
+/* global describe, it */
+
+import 'should';
+import parse from '../../src/special/gulp-load-plugins';
+
+describe('gulp-load-plugins special parser', () => {
+  it('should ignore when file is not `gulpfile.js`', () => {
+    const result = parse('content', '/path/to/not-gulpfile.js', [], '/path/to');
+    result.should.deepEqual([]);
+  });
+
+  const testCases = {
+    'dependency with pattern `gulp-*`': {
+      dependency: 'gulp-jshint',
+      code: `
+        const gulpLoadPlugins = require('gulp-load-plugins');
+        const $ = gulpLoadPlugins();
+        $.jshint();
+      `,
+    },
+    'dependency with pattern `gulp.*`': {
+      dependency: 'gulp.concat',
+      code: `
+        const $ = require('gulp-load-plugins')();
+        $.concat();
+      `,
+    },
+    'dependency with name containing multiple dash signs': {
+      dependency: 'gulp-this-plugin',
+      code: `
+        require('gulp-load-plugins')().thisPlugin();
+      `,
+    },
+    'scoped dependency': {
+      dependency: '@scope/gulp-plugin',
+      code: `
+        import gulpLoadPlugins from 'gulp-load-plugins';
+        const $ = gulpLoadPlugins();
+        $.scope.plugin();
+      `,
+    },
+  };
+
+  Object.keys(testCases).forEach(name =>
+    it(`should recognize ${name}`, () => {
+      const testCase = testCases[name];
+      const result = parse(
+        testCase.code,
+        '/path/to/gulpfile.js',
+        [testCase.dependency, 'gulp-load-plugins'],
+        '/path/to'
+      );
+
+      result.should.deepEqual([testCase.dependency]);
+    }));
+});


### PR DESCRIPTION
Related to #18 

- Use `babel-traverse` to walk through the AST to figure out which packages are loaded by gulp-load-plugins.
- Add simple test cases to support.
- Only `gulp-*` and `gulp.*` are supported.