### PR TITLE
Remove the peer dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Depcheck is a tool to analysis the dependencies in a project, and figures out wh
 
 [![Dependency Status](https://david-dm.org/depcheck/depcheck.svg)](https://david-dm.org/depcheck/depcheck)
 [![devDependency Status](https://david-dm.org/depcheck/depcheck/dev-status.svg)](https://david-dm.org/depcheck/depcheck#info=devDependencies)
-[![peerDependency Status](https://david-dm.org/depcheck/depcheck/peer-status.svg)](https://david-dm.org/depcheck/depcheck#info=peerDependencies)
 
 ## Installation
 
@@ -28,10 +27,10 @@ Depcheck not only recognizes the dependencies in JavaScript file, but also suppo
 - JavaScript (ES5, ES6 and ES7)
 - [React JSX](http://facebook.github.io/react/docs/jsx-in-depth.html)
 - [CoffeeScript](http://coffeescript.org/)
-- [Typescript](http://www.typescriptlang.org/) (by `typescript` as peer dependency)
-- [SASS and SCSS](http://sass-lang.com/) (by `node-sass` as peer dependency)
+- [Typescript](http://www.typescriptlang.org/) (with `typescript` dependency)
+- [SASS and SCSS](http://sass-lang.com/) (with `node-sass` dependency)
 
-To get the syntax support by peer dependency, please install the corresponding package explicitly. For example, for Typescript user, install depcheck with `typescript` package:
+To get the syntax support by external dependency, please install the corresponding package explicitly. For example, for Typescript user, install depcheck with `typescript` package:
 
 ```
 npm install -g depcheck typescript

--- a/false-alert.js
+++ b/false-alert.js
@@ -1,0 +1,10 @@
+/**
+ * I am using this file to avoid false alert in this project.
+ * It is not good, however it works.
+ * The typescript and node-sass are parsers as peer dependencies.
+ * However, because of NPM's bug, it is blocking users.
+ * They are only mentioned in README and declared in devDependencies for testing.
+ * Reference: https://github.com/depcheck/depcheck/issues/130
+ */
+import 'node-sass';
+import 'typescript';

--- a/package.json
+++ b/package.json
@@ -71,9 +71,5 @@
     "patch-version": "^0.1.1",
     "should": "^8.0.0",
     "typescript": "^1.8.0"
-  },
-  "peerDependencies": {
-    "node-sass": "^3.4.0",
-    "typescript": "^1.8.0"
   }
 }


### PR DESCRIPTION
It is blocking `npm shrinkwrap` (https://github.com/dylang/npm-check/issues/108) caused by NPM bug (https://github.com/npm/npm/issues/10836).

However, keep #130 open to find a better solution for *optional peer dependencies* management.