### PR TITLE
Feat/refinement nodejs in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - 3
   - 4
   - 5
+  - 6
 
 script:
   - npm run depcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 language: node_js
 
 node_js:
+  - 0.10
   - 0.12
   - 4
   - 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: node_js
 
 node_js:
   - 0.12
-  - 3
   - 4
   - 5
   - 6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
   - nodejs_version: 3
   - nodejs_version: 4
   - nodejs_version: 5
+  - nodejs_version: 6
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   matrix:
+  - nodejs_version: 0.10
   - nodejs_version: 0.12
   - nodejs_version: 4
   - nodejs_version: 5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 environment:
   matrix:
   - nodejs_version: 0.12
-  - nodejs_version: 3
   - nodejs_version: 4
   - nodejs_version: 5
   - nodejs_version: 6


### PR DESCRIPTION
for some reason, tests on my machine are not passing, so i took a look at nodejs versions used for testing in CI and found a room for improvement:

* add v6, cause its latest and will be lts in the future
* remove v3, because its not one of the latest and not LTS as well
* add v0.10, because its LTS and imho every tool should work there to support enterprise

About the latest thing: from my experience only thing to do here is to polyfill promises and latest nodejs core APIs — i can help here.

what do you think?