### PR TITLE
ignore TypeScript `@types` packages by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,8 +40,11 @@ export default function depcheck(rootDir, options, callback) {
 
   const withoutDev = getOption('withoutDev');
   const ignoreBinPackage = getOption('ignoreBinPackage');
-  const ignoreMatches = getOption('ignoreMatches');
   const ignoreDirs = lodash.union(defaultOptions.ignoreDirs, options.ignoreDirs);
+  // The "@types/" scope is reserved for type declarations used in TypeScript projects. They are only used
+  // during build and are never referenced in the application. We ignore them by default so that depcheck
+  // doesn't fail for TypeScript projects by default.
+  const ignoreMatches = getOption('ignoreMatches') || ['@types/*'];
 
   const detectors = getOption('detectors');
   const parsers = lodash(getOption('parsers'))

--- a/src/index.js
+++ b/src/index.js
@@ -41,10 +41,12 @@ export default function depcheck(rootDir, options, callback) {
   const withoutDev = getOption('withoutDev');
   const ignoreBinPackage = getOption('ignoreBinPackage');
   const ignoreDirs = lodash.union(defaultOptions.ignoreDirs, options.ignoreDirs);
-  // The "@types/" scope is reserved for type declarations used in TypeScript projects. They are only used
-  // during build and are never referenced in the application. We ignore them by default so that depcheck
-  // doesn't fail for TypeScript projects by default.
-  const ignoreMatches = getOption('ignoreMatches') || ['@types/*'];
+  const ignoreMatches = getOption('ignoreMatches');
+
+  // The "@types/" scope is reserved for type declarations used in TypeScript projects. They are
+  // only used during build and are never referenced in the application. We always ignore them
+  // so that depcheck doesn't fail for TypeScript projects by default.
+  ignoreMatches.push('@types/*');
 
   const detectors = getOption('detectors');
   const parsers = lodash(getOption('parsers'))

--- a/test/fake_modules/ignore_npm_@types/index.js
+++ b/test/fake_modules/ignore_npm_@types/index.js
@@ -1,0 +1,3 @@
+/* eslint-disable no-console */
+
+console.log("I'm bad!");

--- a/test/fake_modules/ignore_npm_@types/package.json
+++ b/test/fake_modules/ignore_npm_@types/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "@types/a": "^0.0.1",
+    "@types/b": "^0.1.0",
+    "@types/c": "^1.0.0",
+    "optimist": "~0.6.0"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -54,6 +54,18 @@ describe('depcheck', () => {
       error.should.be.instanceof(SyntaxError);
     }));
 
+  it('should ignore typescript `@types` packages', () =>
+    check('ignore_npm_@types', {}).then(unused => {
+      unused.should.deepEqual({
+        dependencies: [ 'optimist' ],
+        devDependencies: [],
+        missing: {},
+        using: {},
+        invalidFiles: {},
+        invalidDirs: {}
+      });
+    }));
+
   it('should allow dynamic package metadata', () =>
     check('bad', {
       package: {


### PR DESCRIPTION
Fixes #163

The "@types/" scope is reserved for type declarations used in TypeScript projects. They are only used during build and are never referenced in the application.

This change ignores them by default so that depcheck doesn't fail for TypeScript projects by default. In the future, we could add additional logic to check each type package and detect if it's sibling-package (that it declares types for) exists as well.
