### PR TITLE
Allow additional ESLint config file names.

### DIFF
--- a/src/special/eslint.js
+++ b/src/special/eslint.js
@@ -87,7 +87,7 @@ function checkConfig(config, rootDir) {
 
 export default function parseESLint(content, filename, deps, rootDir) {
   const basename = path.basename(filename);
-  if (basename === '.eslintrc') {
+  if (/^\.eslintrc(\.json|\.js|\.yml|\.yaml)?$/.test(basename)) {
     const config = parse(content);
     return checkConfig(config, rootDir);
   }

--- a/test/special/eslint.js
+++ b/test/special/eslint.js
@@ -99,10 +99,18 @@ const testCases = [
 ];
 
 function testEslint(deps, content) {
-  const result = eslintSpecialParser(
-    content, '/path/to/.eslintrc', deps, __dirname);
+  [
+    '/path/to/.eslintrc',
+    '/path/to/.eslintrc.js',
+    '/path/to/.eslintrc.json',
+    '/path/to/.eslintrc.yml',
+    '/path/to/.eslintrc.yaml',
+  ].forEach(pathToEslintrc => {
+    const result = eslintSpecialParser(
+      content, pathToEslintrc, deps, __dirname);
 
-  result.should.deepEqual(deps);
+    result.should.deepEqual(deps);
+  });
 }
 
 describe('eslint special parser', () => {


### PR DESCRIPTION
According to [ESLint documentation](http://eslint.org/docs/user-guide/configuring#configuration-file-formats), a config file may have an extension. Hence I replaced the hard-coded comparison by a regular expression that matches all possible file names.