### PR TITLE
Replace isparata with nyc to collect coverage

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,5 +6,12 @@
   "presets": [
     "es2015",
     "stage-2"
-  ]
+  ],
+  "env": {
+    "test": {
+      "plugins": [
+        "istanbul"
+      ]
+    }
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,8 @@ node_modules
 # Babel compiled code
 dist
 
+# Nyc output
+.nyc_output
+
 # Vim temporary file
 *.swp

--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ src/
 test/
 build/
 coverage/
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
   - npm run depcheck-json
   - npm run lint
   - npm run test-coverage
-  - cat ./coverage/coverage.json | ./node_modules/codecov.io/bin/codecov.io.js
+  - cat ./coverage/coverage.lcov | ./node_modules/.bin/codecov
 
 before_deploy:
   - ./node_modules/.bin/patch-version

--- a/false-alert.js
+++ b/false-alert.js
@@ -10,7 +10,7 @@ import 'node-sass';
 import 'typescript';
 
 /**
- * Explicitly declare istanbul at version 0.4.4, otherwise isparta is not collecting coverage data.
- * See https://github.com/douglasduteil/isparta/issues/126
+ * Recongnize the required module by nyc. See depcheck/depcheck#183
  */
-import 'istanbul';
+import 'babel-polyfill';
+import 'babel-register';

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prepublish": "npm run compile && npm run component",
     "lint": "node-version-gte-4 && eslint ./src ./test ./build || node-version-lt-4",
     "test": "babel-node node_modules/mocha/bin/_mocha ./test ./test/special --timeout 10000",
-    "test-coverage": "cross-env NODE_ENV=test nyc mocha ./test ./test/special --timeout 20000 && nyc report --reporter=text-lcov > ./coverage/coverage.lcov"
+    "test-coverage": "babel-node node_modules/cross-env/bin/cross-env.js NODE_ENV=test nyc mocha ./test ./test/special --timeout 20000 && nyc report --reporter=text-lcov > ./coverage/coverage.lcov"
   },
   "author": {
     "name": "Djordje Lukic",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prepublish": "npm run compile && npm run component",
     "lint": "node-version-gte-4 && eslint ./src ./test ./build || node-version-lt-4",
     "test": "babel-node node_modules/mocha/bin/_mocha ./test ./test/special --timeout 10000",
-    "test-coverage": "babel-node node_modules/isparta/bin/isparta cover node_modules/mocha/bin/_mocha -- ./test ./test/special --timeout 10000"
+    "test-coverage": "cross-env NODE_ENV=test nyc mocha ./test ./test/special --timeout 20000 && nyc report --reporter=text-lcov > ./coverage/coverage.lcov"
   },
   "author": {
     "name": "Djordje Lukic",
@@ -63,10 +63,14 @@
     "babel-cli": "^6.1.1",
     "babel-eslint": "^7.0.0",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-istanbul": "^3.0.0",
     "babel-plugin-transform-object-assign": "^6.1.18",
+    "babel-polyfill": "^6.16.0",
     "babel-preset-es2015": "^6.0.15",
     "babel-preset-stage-2": "^6.0.15",
+    "babel-register": "^6.18.0",
     "codecov.io": "^0.1.6",
+    "cross-env": "^3.1.3",
     "depcheck-web": "^0.1.0",
     "eslint": "^3.10.1",
     "eslint-config-airbnb": "^13.0.0",
@@ -74,13 +78,28 @@
     "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-react": "^6.7.0",
     "fs-promise": "^1.0.0",
-    "isparta": "^4.0.0",
-    "istanbul": "0.4.4",
     "mocha": "^3.0.0",
     "node-sass": "^3.4.0",
     "node-version-check": "^2.1.1",
+    "nyc": "^10.0.0",
     "patch-version": "^0.1.1",
     "should": "^11.0.0",
     "typescript": "^1.8.0"
+  },
+  "nyc": {
+    "sourceMap": false,
+    "instrument": false,
+    "exclude": [
+      "dist",
+      "test"
+    ],
+    "require": [
+      "babel-polyfill",
+      "babel-register"
+    ],
+    "reporter": [
+      "html",
+      "text"
+    ]
   }
 }


### PR DESCRIPTION
- Isparata is in maintaince period
- Depcheck does not support nyc yet, Tracked by issue #183 