### PR TITLE
allow babel webpack configs

### DIFF
--- a/src/special/webpack.js
+++ b/src/special/webpack.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import lodash from 'lodash';
 
-const webpackConfigRegex = /webpack(\..+)?\.config.js/;
+const webpackConfigRegex = /webpack(\..+)?\.config\.(babel\.)?js/;
 const loaderTemplates = ['*-webpack-loader', '*-web-loader', '*-loader', '*'];
 
 function extractLoaders(item) {

--- a/test/special/webpack.js
+++ b/test/special/webpack.js
@@ -9,6 +9,8 @@ const configFileNames = [
   'webpack.config.js',
   'webpack.development.config.js',
   'webpack.production.config.js',
+  'webpack.config.babel.js',
+  'webpack.prod.config.babel.js',
 ];
 
 const testCases = [


### PR DESCRIPTION
Webpack provides the ability to append '.babel.js' instead of '.js', and the config will be parsed by babel before webpack uses it.

Webpack supports this using [interpret](https://github.com/js-cli/js-interpret/blob/master/index.js) and it's mentioned in https://github.com/webpack/webpack/issues/1403

I currently use it for all my configs, so `special` is not picking them up