### PR TITLE
A new detector to discover express view engine

### DIFF
--- a/doc/pluggable-design.md
+++ b/doc/pluggable-design.md
@@ -97,7 +97,12 @@ On the parse error case, throw `SyntaxError` exception and depcheck will capture
 
 After the file content is converted into an AST, the detectors are responsible to walk on each AST nodes to report dependency packages.
 
-Depcheck ships the detector for `require` function as `requireCallExpreesion` detector, for ES6 `import` declaration as `importDeclaration` detector, and for `grunt.tasks.loadNpmTasks` function as `gruntLoadTaskCallExpression` detector.
+Depcheck ships these detectors:
+
+- `requireCallExpreesion` detector for `require` function
+- `importDeclaration` detector for ES6 `import` declaration
+- `gruntLoadTaskCallExpression` detector for `grunt.tasks.loadNpmTasks` function
+- `expressViewEngine` detector for Express [view engine](https://expressjs.com/en/guide/using-template-engines.html)
 
 ### Use Detector From API
 

--- a/src/component.json
+++ b/src/component.json
@@ -9,6 +9,7 @@
     "typescript"
   ],
   "detector": [
+    "expressViewEngine",
     "gruntLoadTaskCallExpression",
     "importDeclaration",
     "requireCallExpression",

--- a/src/detector/expressViewEngine.js
+++ b/src/detector/expressViewEngine.js
@@ -1,6 +1,6 @@
 import lodash from 'lodash';
 
-export default function detectExpressViewEngine(node) {
+export default function expressViewEngine(node) {
   return node.type === 'CallExpression' &&
     node.callee &&
     node.callee.property &&

--- a/src/detector/expressViewEngine.js
+++ b/src/detector/expressViewEngine.js
@@ -1,0 +1,14 @@
+import lodash from 'lodash';
+
+export default function detectExpressViewEngine(node) {
+  return node.type === 'CallExpression' &&
+    node.callee &&
+    node.callee.property &&
+    node.callee.property.name === 'set' &&
+    node.arguments[0] &&
+    node.arguments[0].value === 'view engine' &&
+    node.arguments[1] &&
+    lodash.isString(node.arguments[1].value)
+    ? [node.arguments[1].value]
+    : [];
+}

--- a/src/detector/requireCallExpression.js
+++ b/src/detector/requireCallExpression.js
@@ -1,6 +1,6 @@
 import lodash from 'lodash';
 
-export default function detectRequireCallExpression(node) {
+export default function requireCallExpression(node) {
   return node.type === 'CallExpression' &&
     node.callee &&
     node.callee.type === 'Identifier' &&

--- a/test/cli.js
+++ b/test/cli.js
@@ -30,6 +30,10 @@ function makeArgv(module, options) {
     argv.push(`--ignore-dirs=${options.ignoreDirs.join(',')}`);
   }
 
+  if (options.detectors) {
+    argv.push(`--detectors=${options.detectors.map(f => f.name).join(',')}`);
+  }
+
   if (options.argv && options.argv.length) {
     argv.push(...options.argv);
   }

--- a/test/fake_modules/express_view_engine/index.js
+++ b/test/fake_modules/express_view_engine/index.js
@@ -1,0 +1,4 @@
+const express = require('express');
+
+const app = express();
+app.set('view engine', 'ejs');

--- a/test/fake_modules/express_view_engine/package.json
+++ b/test/fake_modules/express_view_engine/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "ejs": "2.5.5",
+    "express": "4.14.1"
+  }
+}

--- a/test/spec.js
+++ b/test/spec.js
@@ -1,3 +1,5 @@
+import depcheck from '../src/index';
+
 export default [
   {
     name: 'missing module for require.resolve when missing in package.json',
@@ -558,6 +560,25 @@ export default [
       using: {
         babel: ['package.json'],
         chai: ['package.json'],
+      },
+    },
+  },
+  {
+    name: 'discover dependency from express view engine setting',
+    module: 'express_view_engine',
+    options: {
+      detectors: [
+        depcheck.detector.requireCallExpression,
+        depcheck.detector.expressViewEngine,
+      ],
+    },
+    expected: {
+      dependencies: [],
+      devDependencies: [],
+      missing: {},
+      using: {
+        ejs: ['index.js'],
+        express: ['index.js'],
       },
     },
   },


### PR DESCRIPTION
The PR implements a new detector `expressViewEngine`.

I don't add this detector to default options because I'm not sure if it should be enable by default.

The current test tool doesn't support giving `detectors` in `options` in `spec.js`. I have to modify it a bit. A tricky thing is that a naming rule is required for detectors to make cli test works: function name must be the same as its public name defined in `component.json`.