### PR TITLE
Switch deprecated script prepublish to prepublishOnly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ node_js:
   - 8
 
 script:
+  - npm run compile
+  - npm run component
   - npm run depcheck
   - npm run depcheck-json
   - npm run lint

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,8 @@ install:
 test_script:
   - node --version
   - npm --version
+  - npm run compile
+  - npm run component
   - npm run depcheck
   - npm run depcheck-json
   - npm run lint

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "depcheck": "node ./bin/depcheck",
     "depcheck-web": "node ./bin/depcheck --json | depcheck-web",
     "depcheck-json": "node ./bin/depcheck --json | babel-node ./build/check-json",
-    "prepublish": "npm run compile && npm run component",
+    "prepublishOnly": "npm run compile && npm run component",
     "lint": "eslint ./src ./test ./build",
     "test": "babel-node node_modules/mocha/bin/_mocha ./test ./test/special --timeout 10000",
     "test-dependent": "dependent-build",


### PR DESCRIPTION
This switches deprecated script `prepublish` to `prepublishOnly`. 

Relevant article - http://blog.lholmquist.org/npm-prepublish-changes/

Closes #217 