### PR TITLE
Depcheck will detect dependency use in package.json scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ dist
 
 # Dependent-build
 dependent-build
+
+# IDE files
+.idea/
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,6 @@ dist
 # Dependent-build
 dependent-build
 
-# IDE files
+# Jetbrains IDE files
 .idea/
 *.iml

--- a/src/special/package.js
+++ b/src/special/package.js
@@ -1,0 +1,17 @@
+export default function parsePackageJson(content, filepath, deps) {
+
+  // Mark dependencies as "used" if they are used in a script in package.json.
+  if (filepath.endsWith('/package.json')) {
+    // Grab just the scripts section.
+    const scriptsText = JSON.stringify(JSON.parse(content)['scripts']);
+    const depsInScripts = [];
+    for (const dependency of deps) {
+      if (scriptsText.indexOf(dependency) !== -1) {
+        depsInScripts.push(dependency);
+      }
+    }
+    return depsInScripts;
+  }
+
+  return [];
+}

--- a/src/special/package.js
+++ b/src/special/package.js
@@ -1,16 +1,29 @@
 export default function parsePackageJson(content, filepath, deps) {
   // Mark dependencies as "used" if they are used in a script in package.json.
-  if (filepath.endsWith('/package.json')) {
+  if (filepath.match(new RegExp('(\\/|\\\\)package.json$'))) {  // Escaping is fun!
     // Grab just the scripts section.
-    const scriptsText = JSON.stringify(JSON.parse(content).scripts);
-    if (scriptsText) {
-      const depsInScripts = [];
-      for (let i = 0; i < deps.length; i += 1) {
-        if (scriptsText.indexOf(deps[i]) !== -1) {
-          depsInScripts.push(deps[i]);
+    const scripts = JSON.parse(content).scripts;
+
+    if (scripts) {
+      const scriptKeys = Object.keys(scripts);
+
+      if (scriptKeys.length) {
+        // Don't count script titles as dependency use.
+        let scriptsText = '';
+        for (let i = 0; i < scriptKeys.length; i += 1) {
+          scriptsText += `${scripts[scriptKeys[i]]} `;
+        }
+
+        if (scriptsText) {
+          const depsInScripts = [];
+          for (let i = 0; i < deps.length; i += 1) {
+            if (scriptsText.indexOf(deps[i]) !== -1) {
+              depsInScripts.push(deps[i]);
+            }
+          }
+          return depsInScripts;
         }
       }
-      return depsInScripts;
     }
   }
   return [];

--- a/src/special/package.js
+++ b/src/special/package.js
@@ -1,17 +1,17 @@
 export default function parsePackageJson(content, filepath, deps) {
-
   // Mark dependencies as "used" if they are used in a script in package.json.
   if (filepath.endsWith('/package.json')) {
     // Grab just the scripts section.
-    const scriptsText = JSON.stringify(JSON.parse(content)['scripts']);
-    const depsInScripts = [];
-    for (const dependency of deps) {
-      if (scriptsText.indexOf(dependency) !== -1) {
-        depsInScripts.push(dependency);
+    const scriptsText = JSON.stringify(JSON.parse(content).scripts);
+    if (scriptsText) {
+      const depsInScripts = [];
+      for (let i = 0, len = deps.length; i < len; i + 1) {
+        if (scriptsText.indexOf(deps[i]) !== -1) {
+          depsInScripts.push(deps[i]);
+        }
       }
+      return depsInScripts;
     }
-    return depsInScripts;
   }
-
   return [];
 }

--- a/src/special/package.js
+++ b/src/special/package.js
@@ -5,7 +5,7 @@ export default function parsePackageJson(content, filepath, deps) {
     const scriptsText = JSON.stringify(JSON.parse(content).scripts);
     if (scriptsText) {
       const depsInScripts = [];
-      for (let i = 0, len = deps.length; i < len; i + 1) {
+      for (let i = 0; i < deps.length; i += 1) {
         if (scriptsText.indexOf(deps[i]) !== -1) {
           depsInScripts.push(deps[i]);
         }

--- a/test/cli.js
+++ b/test/cli.js
@@ -48,8 +48,8 @@ function testCli(argv) {
   return new Promise(resolve =>
     cli(
       argv,
-      data => (log = data),
-      data => (error = data),
+      data => (log = data), // eslint-disable-line no-return-assign
+      data => (error = data), // eslint-disable-line no-return-assign
       exitCode => resolve({
         log,
         error,
@@ -216,6 +216,6 @@ describe('depcheck command line', () => {
         exitCode.should.equal(-1);
       }));
 
-    after(() => (process.cwd = originalCwd));
+    after(() => (process.cwd = originalCwd)); // eslint-disable-line no-return-assign
   });
 });

--- a/test/fake_modules/package_json_empty_scripts/package.json
+++ b/test/fake_modules/package_json_empty_scripts/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "ts-node": "1.0.0",
+    "some-module": "1.0.0"
+  },
+  "scripts": {}
+}

--- a/test/fake_modules/package_json_no_scripts/package.json
+++ b/test/fake_modules/package_json_no_scripts/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "ts-node": "1.0.0",
+    "some-module": "1.0.0"
+  }
+}

--- a/test/fake_modules/package_json_scripts/package.json
+++ b/test/fake_modules/package_json_scripts/package.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "ts-node": "1.0.0",
+    "some-module": "1.0.0"
+  },
+  "scripts": {
+    "test": "ts-node index.ts"
+  }
+}

--- a/test/spec.js
+++ b/test/spec.js
@@ -582,4 +582,16 @@ export default [
       },
     },
   },
+  // TODO: How to enable the 'package' special parser for this test?
+  {
+    name: 'discover dependencies from package.json scripts',
+    module: 'package_json_scripts',
+    options: {},
+    expected: {
+      dependencies: ['ts-node', 'some-module'],
+      devDependencies: [],
+      missing: {},
+      using: {},
+    },
+  },
 ];

--- a/test/special/package.js
+++ b/test/special/package.js
@@ -1,0 +1,31 @@
+/* global describe, it */
+
+import 'should';
+import fs from 'fs';
+import path from 'path';
+import parse from '../../src/special/package';
+
+describe('package.json special parser', () => {
+  it('should ignore when filename is not supported', () => {
+    const result = parse('content', 'not-supported.txt', [], __dirname);
+    result.should.deepEqual([]);
+  });
+
+  it('should recognize mocha options specified from scripts', () => {
+    const rootDir = path.resolve(__dirname, '../fake_modules/package_json_scripts');
+    const packagePath = path.resolve(rootDir, 'package.json');
+    const packageContent = fs.readFileSync(packagePath, 'utf-8');
+    const dependencies = Object.keys(JSON.parse(packageContent).dependencies);
+    const result = parse(packageContent, packagePath, dependencies, rootDir);
+    result.should.deepEqual(['ts-node']);
+  });
+
+  it('should not fail to parse package.json when the scripts key is missing', () => {
+    const rootDir = path.resolve(__dirname, '../fake_modules/package_json_no_scripts');
+    const packagePath = path.resolve(rootDir, 'package.json');
+    const packageContent = fs.readFileSync(packagePath, 'utf-8');
+    const dependencies = Object.keys(JSON.parse(packageContent).dependencies);
+    const result = parse(packageContent, packagePath, dependencies, rootDir);
+    result.should.deepEqual([]);
+  });
+});

--- a/test/special/package.js
+++ b/test/special/package.js
@@ -11,7 +11,7 @@ describe('package.json special parser', () => {
     result.should.deepEqual([]);
   });
 
-  it('should recognize mocha options specified from scripts', () => {
+  it('should find dependencies used in scripts', () => {
     const rootDir = path.resolve(__dirname, '../fake_modules/package_json_scripts');
     const packagePath = path.resolve(rootDir, 'package.json');
     const packageContent = fs.readFileSync(packagePath, 'utf-8');
@@ -20,7 +20,16 @@ describe('package.json special parser', () => {
     result.should.deepEqual(['ts-node']);
   });
 
-  it('should not fail to parse package.json when the scripts key is missing', () => {
+  it('should not fail to check package.json when the scripts value is empty', () => {
+    const rootDir = path.resolve(__dirname, '../fake_modules/package_json_empty_scripts');
+    const packagePath = path.resolve(rootDir, 'package.json');
+    const packageContent = fs.readFileSync(packagePath, 'utf-8');
+    const dependencies = Object.keys(JSON.parse(packageContent).dependencies);
+    const result = parse(packageContent, packagePath, dependencies, rootDir);
+    result.should.deepEqual([]);
+  });
+
+  it('should not fail to check package.json when the scripts key is missing', () => {
     const rootDir = path.resolve(__dirname, '../fake_modules/package_json_no_scripts');
     const packagePath = path.resolve(rootDir, 'package.json');
     const packageContent = fs.readFileSync(packagePath, 'utf-8');


### PR DESCRIPTION
* Depcheck will detect dependency use in package.json scripts.
* Added Jetbrains IDE files to .gitignore.
* Fixes #222

I don't know how to use the 'special' parsers with tests in spec.js, if someone could help me with that I'd be very grateful. :smile: 