### PR TITLE
style: Switch off eslint rule linebreak-style

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,3 +2,4 @@ parser: babel-eslint
 extends: airbnb
 rules:
   import/no-dynamic-require: off
+  linebreak-style: off


### PR DESCRIPTION
The rule conflicts with git `core.autocrlf`, enabled through `.gitattributes`, on windows.

**Before**
```
λ yarn run lint
yarn run v1.2.0
$ eslint ./src ./test ./build

E:\Projects\repos\depcheck\src\check.js
    1:21  error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
    2:25  error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
    3:29  error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
    4:31  error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
    5:35  error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
    6:46  error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
    7:55  error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
    8:36  error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
    9:1   error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
   10:25  error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
   11:8   error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
   12:49  error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
....

✖ 3351 problems (3351 errors, 0 warnings)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

**After**
```
λ yarn run lint
yarn run v1.2.0
$ eslint ./src ./test ./build
Done in 7.64s.
```