### PR TITLE
Fix scoped ESLint module check

### DIFF
--- a/src/special/eslint.js
+++ b/src/special/eslint.js
@@ -53,6 +53,10 @@ function isEslintConfigAFullyQualifiedModuleName(specifier) {
   return lodash.startsWith(specifier, 'eslint-config-');
 }
 
+function isEslintConfigModuleJustAScope(specifier) {
+  return !lodash.includes(specifier, '/');
+}
+
 function resolvePresetPackage(preset, rootDir) {
   // inspired from https://github.com/eslint/eslint/blob/5b4a94e26d0ef247fe222dacab5749805d9780dd/lib/config/config-file.js#L347
   if (isEslintConfigAnAbsolutePath(preset)) {
@@ -62,13 +66,12 @@ function resolvePresetPackage(preset, rootDir) {
     return path.resolve(rootDir, preset);
   }
   if (isEslintConfigAScopedModule(preset)) {
-    const scope = preset.substring(0, preset.indexOf('/'));
-    const module = preset.substring(preset.indexOf('/') + 1);
-
-    if (isEslintConfigAFullyQualifiedModuleName(module)) {
-      return preset;
+    // Based on documentation for ESLint:
+    // https://eslint.org/docs/developer-guide/shareable-configs#npm-scoped-modules
+    if (isEslintConfigModuleJustAScope(preset)) {
+      return `${preset}/eslint-config`;
     }
-    return `${scope}/eslint-config-${module}`;
+    return preset;
   }
   if (isEslintConfigAFullyQualifiedModuleName(preset)) {
     return preset;

--- a/test/special/eslint.js
+++ b/test/special/eslint.js
@@ -97,21 +97,30 @@ const testCases = [
     expected: [],
   },
   {
-    name: 'handle config of scoped module',
-    content: {
-      extends: '@my-org/short-customized',
-    },
-    expected: [
-      '@my-org/eslint-config-short-customized',
-    ],
-  },
-  {
     name: 'handle config of scoped module with full name',
     content: {
       extends: '@my-org/eslint-config-long-customized',
     },
     expected: [
       '@my-org/eslint-config-long-customized',
+    ],
+  },
+  {
+    name: 'handle config of scoped module called eslint-config',
+    content: {
+      extends: '@my-org/eslint-config',
+    },
+    expected: [
+      '@my-org/eslint-config',
+    ],
+  },
+  {
+    name: 'handle config of scoped module with just the scope',
+    content: {
+      extends: '@my-org',
+    },
+    expected: [
+      '@my-org/eslint-config',
     ],
   },
 ];


### PR DESCRIPTION
Based on ESLint documentation here:
https://eslint.org/docs/developer-guide/shareable-configs#npm-scoped-modules

The old support for ESLint scoped modules had a few issues:

It did not support a scoped module named `eslint-config`
This lead to a false positive missing dependency of
`@scope/eslint-config`

It did not support the shorthand that ESLint allows of just giving
the scope like this: `@scope` which ESLint behind the scenes makes
into `@scope/eslint-config`

It supported a version that ESLint specifically does not support
looking like this: `@scope/name`
The implementation would prefix the name with `eslint-config-`
making it `@scope/eslint-config-name` which could potentially lead to
resolution errors.