### PR TITLE
CLI: exit with -1 when there are missing dependencies

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -118,8 +118,7 @@ export default function cli(args, log, error, exit) {
       skipMissing: opt.argv.skipMissing,
     }))
     .then(result => print(result, log, opt.argv.json))
-    .then(({ dependencies: deps, devDependencies: devDeps }) =>
-      exit(opt.argv.json || (deps.length === 0 && devDeps.length) === 0 ? 0 : -1))
+    .then(result => exit((opt.argv.json || noIssue(result)) ? 0 : -1))
     .catch((errorMessage) => {
       error(errorMessage);
       exit(-1);


### PR DESCRIPTION
I'm not sure if it's a bug or a feature, and I didn't see any issue about that yet, but since it's a simple fix I was like, might as well make a PR.

Currently depcheck doesn't exits with an error when there's only missing dependencies, and doesn't provide an option to do so:

```
$ depcheck
Missing dependencies
* moment
$ echo $?
0
```

This PR exits with -1 also when there are missing dependencies.