### PR TITLE
Add ability to skip calculation of missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@ All of the arguments are optional:
 
 `--ignore-bin-package=[true|false]`: A flag to indicate if depcheck ignores the packages containing bin entry. The default value is `true`.
 
+`--skip-missing=[true|false]`: A flag to indicate if depcheck skips calculation of missing dependencies. The default value is `false`.
+
 `--json`: Output results in JSON. When not specified, depcheck outputs in human friendly format.
 
-`--ignores`: A comma separated array containing package names to ignore. It can be glob expressions. Example, `--ignores=eslint,babel-*`.
+`--ignores`: A comma separated array containing package names to ignore. It can be glob expressions. Example, `--ignores="eslint,babel-*"`.
 
 `--ignore-dirs`: A comma separated array containing directory names to ignore. Example, `--ignore-dirs=dist,coverage`.
 
@@ -89,6 +91,7 @@ import depcheck from 'depcheck';
 const options = {
   withoutDev: false, // [DEPRECATED] check against devDependencies
   ignoreBinPackage: false, // ignore the packages with bin entry
+  skipMissing: false, // skip calculation of missing dependencies
   ignoreDirs: [ // folder with these names will be ignored
     'sandbox',
     'dist',

--- a/src/check.js
+++ b/src/check.js
@@ -185,7 +185,7 @@ function checkDirectory(dir, rootDir, ignoreDirs, deps, parsers, detectors) {
   });
 }
 
-function buildResult(result, deps, devDeps, peerDeps, optionalDeps) {
+function buildResult(result, deps, devDeps, peerDeps, optionalDeps, skipMissing) {
   const usingDepsLookup = lodash(result.using)
     // { f1:[d1,d2,d3], f2:[d2,d3,d4] }
     .toPairs()
@@ -206,10 +206,12 @@ function buildResult(result, deps, devDeps, peerDeps, optionalDeps) {
   const allDeps = deps.concat(devDeps).concat(peerDeps).concat(optionalDeps);
   const missingDeps = lodash.difference(usingDeps, allDeps);
 
-  const missingDepsLookup = lodash(missingDeps)
-    .map(missingDep => [missingDep, usingDepsLookup[missingDep]])
-    .fromPairs()
-    .value();
+  const missingDepsLookup = skipMissing
+    ? []
+    : lodash(missingDeps)
+      .map(missingDep => [missingDep, usingDepsLookup[missingDep]])
+      .fromPairs()
+      .value();
 
   return {
     dependencies: lodash.difference(deps, usingDeps),
@@ -224,6 +226,7 @@ function buildResult(result, deps, devDeps, peerDeps, optionalDeps) {
 export default function check({
   rootDir,
   ignoreDirs,
+  skipMissing,
   deps,
   devDeps,
   peerDeps,
@@ -233,5 +236,5 @@ export default function check({
 }) {
   const allDeps = lodash.union(deps, devDeps);
   return checkDirectory(rootDir, rootDir, ignoreDirs, allDeps, parsers, detectors)
-    .then(result => buildResult(result, deps, devDeps, peerDeps, optionalDeps));
+    .then(result => buildResult(result, deps, devDeps, peerDeps, optionalDeps, skipMissing));
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -79,13 +79,16 @@ export default function cli(args, log, error, exit) {
     .boolean([
       'dev',
       'ignore-bin-package',
+      'skip-missing',
     ])
     .default({
       dev: true,
       'ignore-bin-package': false,
+      'skip-missing': false,
     })
     .describe('dev', '[DEPRECATED] Check on devDependecies')
     .describe('ignore-bin-package', 'Ignore package with bin entry')
+    .describe('skip-missing', 'Skip calculation of missing dependencies')
     .describe('json', 'Output results to JSON')
     .describe('ignores', 'Comma separated package list to ignore')
     .describe('ignore-dirs', 'Comma separated folder names to ignore')
@@ -112,6 +115,7 @@ export default function cli(args, log, error, exit) {
       parsers: getParsers(opt.argv.parsers),
       detectors: getDetectors(opt.argv.detectors),
       specials: getSpecials(opt.argv.specials),
+      skipMissing: opt.argv.skipMissing,
     }))
     .then(result => print(result, log, opt.argv.json))
     .then(({ dependencies: deps, devDependencies: devDeps }) =>

--- a/src/constants.js
+++ b/src/constants.js
@@ -31,6 +31,7 @@ export const defaultOptions = {
     'node_modules',
     'bower_components',
   ],
+  skipMissing: false,
   parsers: {
     '*.js': availableParsers.jsx,
     '*.jsx': availableParsers.jsx,

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ export default function depcheck(rootDir, options, callback) {
   const ignoreBinPackage = getOption('ignoreBinPackage');
   const ignoreMatches = getOption('ignoreMatches');
   const ignoreDirs = lodash.union(defaultOptions.ignoreDirs, options.ignoreDirs);
+  const skipMissing = getOption('skipMissing');
 
   const detectors = getOption('detectors');
   const parsers = lodash(getOption('parsers'))
@@ -60,6 +61,7 @@ export default function depcheck(rootDir, options, callback) {
   return check({
     rootDir,
     ignoreDirs,
+    skipMissing,
     deps,
     devDeps,
     peerDeps,

--- a/test/cli.js
+++ b/test/cli.js
@@ -38,6 +38,10 @@ function makeArgv(module, options) {
     argv.push(...options.argv);
   }
 
+  if (options.skipMissing !== undefined) {
+    argv.push(`--skip-missing=${options.skipMissing}`);
+  }
+
   return argv;
 }
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -404,6 +404,38 @@ export default [
     },
   },
   {
+    name: 'output empty missing dependencies when skipMissing is true',
+    module: 'missing',
+    options: {
+      skipMissing: true,
+    },
+    expected: {
+      dependencies: [],
+      devDependencies: [],
+      missing: {},
+      using: {
+        'missing-dep': ['index.js'],
+      },
+    },
+  },
+  {
+    name: 'output missing dependencies when skipMissing is false',
+    module: 'missing',
+    options: {
+      skipMissing: false,
+    },
+    expected: {
+      dependencies: [],
+      devDependencies: [],
+      missing: {
+        'missing-dep': ['index.js'],
+      },
+      using: {
+        'missing-dep': ['index.js'],
+      },
+    },
+  },
+  {
     name: 'handle require call without parameters',
     module: 'require_nothing',
     options: {


### PR DESCRIPTION
In some cases, you don't care about missing dependencies. While non-empty missing dependencies do not seem to affect CLI exit code, this might change in the future (https://github.com/depcheck/depcheck/pull/235).

This PR adds simple flag to both JS (`skipMissing`) and CLI (`--skip-missing`). It is optional (defaults to `false` - the original behavior).

Todo:
- [x] Add option to skip calculation of missing depenedencies
- [x] Add unit tests
- [x] Update readme