### PR TITLE
Support for eslint's 'plugin:' prefixed specifiers

### DIFF
--- a/test/special/eslint.js
+++ b/test/special/eslint.js
@@ -114,6 +114,42 @@ const testCases = [
       '@my-org/eslint-config-long-customized',
     ],
   },
+  {
+    name: 'handle config from plugin with short name',
+    content: {
+      extends: 'plugin:node/recommended',
+    },
+    expected: [
+      'eslint-plugin-node',
+    ],
+  },
+  {
+    name: 'handle config from plugin with full name',
+    content: {
+      extends: 'plugin:eslint-plugin-node/recommended',
+    },
+    expected: [
+      'eslint-plugin-node',
+    ],
+  },
+  {
+    name: 'handle config from scoped plugin with short name',
+    content: {
+      extends: 'plugin:@my-org/short-customized/recommended',
+    },
+    expected: [
+      '@my-org/eslint-plugin-short-customized',
+    ],
+  },
+  {
+    name: 'handle config from scoped plugin with full name',
+    content: {
+      extends: 'plugin:@my-org/eslint-plugin-long-customized/recommended',
+    },
+    expected: [
+      '@my-org/eslint-plugin-long-customized',
+    ],
+  },
 ];
 
 function testEslint(deps, content) {


### PR DESCRIPTION
ESLint supports loading configuration files from plugins. In the `eslintrc.*`'s `extends` property, you can specify a config name with a special `plugin:` prefix. Like loading config from package modules, you can specify a short name in lieu of a full module name. However, for `plugin:` prefixed names,  short names resolve to `eslint-plugin-${shortName}` instead of `eslint-config-${shortName}`. This PR takes cares of that use case.

Here's the link to ESLint's documentation on loading config from plugins:
https://eslint.org/docs/user-guide/configuring#using-the-configuration-from-a-plugin