### PR TITLE
Add support for TSLint

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The *special* component is used to recognize the dependencies that are not gener
 
 - `bin` - Dependencies used in npm commands, Travis scripts or other CI scripts
 - `eslint` - [ESLint](https://www.npmjs.com/package/eslint) configuration presets, parsers and plugins
+- `tslint` - [TSLint](https://www.npmjs.com/package/tslint) configuration presets, parsers and plugins
 - `webpack` - [Webpack](https://www.npmjs.com/package/webpack) loaders
 - `babel` - [Babel](https://www.npmjs.com/package/babel) presets and plugins
 - [Grunt](https://www.npmjs.com/package/grunt) plugins

--- a/src/special/tslint.js
+++ b/src/special/tslint.js
@@ -1,0 +1,5 @@
+import parseLinter from '../utils/linters';
+
+export default function parseTSLint(content, filename, deps, rootDir) {
+  return parseLinter('tslint', content, filename, deps, rootDir);
+}

--- a/src/utils/linters.js
+++ b/src/utils/linters.js
@@ -1,0 +1,132 @@
+import path from 'path';
+import yaml from 'js-yaml';
+import lodash from 'lodash';
+import requirePackageName from 'require-package-name';
+import { evaluate } from '../utils';
+
+function parse(content) {
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    // not JSON format
+  }
+
+  try {
+    return yaml.safeLoad(content);
+  } catch (error) {
+    // not YAML format
+  }
+
+  try {
+    return evaluate(`module.exports = ${content}`);
+  } catch (error) {
+    // not valid JavaScript code
+  }
+
+  // parse fail, return nothing
+  return {};
+}
+
+function wrapToArray(obj) {
+  if (!obj) {
+    return [];
+  } else if (lodash.isArray(obj)) {
+    return obj;
+  }
+
+  return [obj];
+}
+
+function isLinterConfigAnAbsolutePath(specifier) {
+  return path.isAbsolute(specifier);
+}
+
+function isLinterConfigARelativePath(specifier) {
+  return lodash.startsWith(specifier, './') || lodash.startsWith(specifier, '../');
+}
+
+function isLinterConfigFromAPlugin(specifier) {
+  return lodash.startsWith(specifier, 'plugin:');
+}
+
+function isLinterConfigFromAScopedModule(specifier) {
+  return lodash.startsWith(specifier, '@');
+}
+
+function isLinterConfigFromAFullyQualifiedModuleName(specifier, prefix) {
+  return lodash.startsWith(specifier, prefix);
+}
+
+function resolvePresetPackage(flavour, preset, rootDir) {
+  // inspired from https://github.com/eslint/eslint/blob/5b4a94e26d0ef247fe222dacab5749805d9780dd/lib/config/config-file.js#L347
+  if (isLinterConfigAnAbsolutePath(preset)) {
+    return preset;
+  }
+  if (isLinterConfigARelativePath(preset)) {
+    return path.resolve(rootDir, preset);
+  }
+
+  const { prefix, specifier } = (
+    isLinterConfigFromAPlugin(preset)
+    ? { prefix: `${flavour}-plugin-`, specifier: preset.substring(preset.indexOf(':') + 1) }
+    : { prefix: `${flavour}-config-`, specifier: preset }
+  );
+
+  if (isLinterConfigFromAScopedModule(specifier)) {
+    const scope = specifier.substring(0, specifier.indexOf('/'));
+    const module = specifier.substring(specifier.indexOf('/') + 1);
+
+    if (isLinterConfigFromAFullyQualifiedModuleName(module, prefix)) {
+      return specifier;
+    }
+    return `${scope}/${prefix}${module}`;
+  }
+  if (isLinterConfigFromAFullyQualifiedModuleName(specifier, prefix)) {
+    return specifier;
+  }
+  return `${prefix}${specifier}`;
+}
+
+function loadConfig(preset, rootDir) {
+  const presetPath = path.isAbsolute(preset)
+    ? preset
+    : path.resolve(rootDir, 'node_modules', preset);
+
+  try {
+    return require(presetPath); // eslint-disable-line global-require
+  } catch (error) {
+    return {}; // silently return nothing
+  }
+}
+
+function checkConfig(flavour, config, rootDir) {
+  const parser = wrapToArray(config.parser);
+  const plugins = wrapToArray(config.plugins).map(plugin => `${flavour}-plugin-${plugin}`);
+
+  const presets = wrapToArray(config.extends)
+    .filter(preset => preset !== `${flavour}:recommended`)
+    .map(preset => resolvePresetPackage(flavour, preset, rootDir));
+
+  const presetPackages = presets
+    .filter(preset => !path.isAbsolute(preset))
+    .map(requirePackageName);
+
+  const presetDeps = lodash(presets)
+    .map(preset => loadConfig(preset, rootDir))
+    .map(presetConfig => checkConfig(flavour, presetConfig, rootDir))
+    .flatten()
+    .value();
+
+  return lodash.union(parser, plugins, presetPackages, presetDeps);
+}
+
+export default function parseLinter(flavour, content, filename, deps, rootDir) {
+  const basename = path.basename(filename);
+  const filenameRegex = new RegExp(`^\\.${flavour}rc(\\.json|\\.js|\\.yml|\\.yaml)?$`);
+  if (filenameRegex.test(basename)) {
+    const config = parse(content);
+    return checkConfig(flavour, config, rootDir);
+  }
+
+  return [];
+}

--- a/test/special/tslint.js
+++ b/test/special/tslint.js
@@ -1,0 +1,155 @@
+/* global describe, it */
+
+import 'should';
+import yaml from 'js-yaml';
+import tslintSpecialParser from '../../src/special/tslint';
+
+const testCases = [
+  {
+    name: 'ignore when user not extends any config in `.tslintrc`',
+    content: {},
+    expected: [],
+  },
+  {
+    name: 'detect specific plugins',
+    content: {
+      plugins: ['mocha'],
+    },
+    expected: [
+      'tslint-plugin-mocha',
+    ],
+  },
+  {
+    name: 'handle tslint config with short name',
+    content: {
+      extends: 'preset',
+    },
+    expected: [
+      'tslint-config-preset',
+    ],
+  },
+  {
+    name: 'handle tslint config with full name',
+    content: {
+      extends: 'tslint-config-preset',
+    },
+    expected: [
+      'tslint-config-preset',
+    ],
+  },
+  {
+    name: 'skip tslint recommended config',
+    content: {
+      extends: 'tslint:recommended',
+    },
+    expected: [],
+  },
+  {
+    name: 'handle config of absolute local path',
+    content: {
+      extends: '/path/to/config',
+    },
+    expected: [],
+  },
+  {
+    name: 'handle config of relative local path',
+    content: {
+      extends: './config',
+    },
+    expected: [],
+  },
+  {
+    name: 'handle config of scoped module',
+    content: {
+      extends: '@my-org/short-customized',
+    },
+    expected: [
+      '@my-org/tslint-config-short-customized',
+    ],
+  },
+  {
+    name: 'handle config of scoped module with full name',
+    content: {
+      extends: '@my-org/tslint-config-long-customized',
+    },
+    expected: [
+      '@my-org/tslint-config-long-customized',
+    ],
+  },
+  {
+    name: 'handle config from plugin with short name',
+    content: {
+      extends: 'plugin:node/recommended',
+    },
+    expected: [
+      'tslint-plugin-node',
+    ],
+  },
+  {
+    name: 'handle config from plugin with full name',
+    content: {
+      extends: 'plugin:tslint-plugin-node/recommended',
+    },
+    expected: [
+      'tslint-plugin-node',
+    ],
+  },
+  {
+    name: 'handle config from scoped plugin with short name',
+    content: {
+      extends: 'plugin:@my-org/short-customized/recommended',
+    },
+    expected: [
+      '@my-org/tslint-plugin-short-customized',
+    ],
+  },
+  {
+    name: 'handle config from scoped plugin with full name',
+    content: {
+      extends: 'plugin:@my-org/tslint-plugin-long-customized/recommended',
+    },
+    expected: [
+      '@my-org/tslint-plugin-long-customized',
+    ],
+  },
+];
+
+function testTslint(deps, content) {
+  [
+    '/path/to/.tslintrc',
+    '/path/to/.tslintrc.js',
+    '/path/to/.tslintrc.json',
+    '/path/to/.tslintrc.yml',
+    '/path/to/.tslintrc.yaml',
+  ].forEach((pathToTslintrc) => {
+    const result = tslintSpecialParser(
+      content, pathToTslintrc, deps, __dirname);
+
+    result.should.deepEqual(deps);
+  });
+}
+
+describe('tslint special parser', () => {
+  it('should ignore when filename is not `.tslintrc`', () => {
+    const result = tslintSpecialParser('content', '/a/file');
+    result.should.deepEqual([]);
+  });
+
+  it('should handle parse error', () =>
+    testTslint([], '{ this is an invalid JSON string'));
+
+  it('should handle non-standard JSON content', () =>
+    testTslint(
+      testCases[1].expected,
+      `${JSON.stringify(testCases[1].content)}\n// this is ignored`));
+
+  describe('with JSON format', () =>
+    testCases.forEach(testCase =>
+      it(`should ${testCase.name}`, () =>
+        testTslint(testCase.expected, JSON.stringify(testCase.content)))));
+
+  describe('with YAML format', () =>
+    testCases.forEach(testCase =>
+      it(`should ${testCase.name}`, () =>
+        testTslint(testCase.expected, yaml.safeDump(testCase.content)))));
+});


### PR DESCRIPTION
The diff is a bit hard to read, here is a diff between the previous `src/special/eslint.js` and the new `src/util/linters.js`:

```diff
--- src/special/eslint.js	2018-08-09 14:54:33.000000000 +0100
+++ src/utils/linters.js	2018-08-09 14:44:03.000000000 +0100
@@ -37,51 +37,51 @@
   return [obj];
 }
 
-function isEslintConfigAnAbsolutePath(specifier) {
+function isLinterConfigAnAbsolutePath(specifier) {
   return path.isAbsolute(specifier);
 }
 
-function isEslintConfigARelativePath(specifier) {
+function isLinterConfigARelativePath(specifier) {
   return lodash.startsWith(specifier, './') || lodash.startsWith(specifier, '../');
 }
 
-function isEslintConfigFromAPlugin(specifier) {
+function isLinterConfigFromAPlugin(specifier) {
   return lodash.startsWith(specifier, 'plugin:');
 }
 
-function isEslintConfigFromAScopedModule(specifier) {
+function isLinterConfigFromAScopedModule(specifier) {
   return lodash.startsWith(specifier, '@');
 }
 
-function isEslintConfigFromAFullyQualifiedModuleName(specifier, prefix) {
+function isLinterConfigFromAFullyQualifiedModuleName(specifier, prefix) {
   return lodash.startsWith(specifier, prefix);
 }
 
-function resolvePresetPackage(preset, rootDir) {
+function resolvePresetPackage(flavour, preset, rootDir) {
   // inspired from https://github.com/eslint/eslint/blob/5b4a94e26d0ef247fe222dacab5749805d9780dd/lib/config/config-file.js#L347
-  if (isEslintConfigAnAbsolutePath(preset)) {
+  if (isLinterConfigAnAbsolutePath(preset)) {
     return preset;
   }
-  if (isEslintConfigARelativePath(preset)) {
+  if (isLinterConfigARelativePath(preset)) {
     return path.resolve(rootDir, preset);
   }
 
   const { prefix, specifier } = (
-    isEslintConfigFromAPlugin(preset)
-    ? { prefix: 'eslint-plugin-', specifier: preset.substring(preset.indexOf(':') + 1) }
-    : { prefix: 'eslint-config-', specifier: preset }
+    isLinterConfigFromAPlugin(preset)
+    ? { prefix: `${flavour}-plugin-`, specifier: preset.substring(preset.indexOf(':') + 1) }
+    : { prefix: `${flavour}-config-`, specifier: preset }
   );
 
-  if (isEslintConfigFromAScopedModule(specifier)) {
+  if (isLinterConfigFromAScopedModule(specifier)) {
     const scope = specifier.substring(0, specifier.indexOf('/'));
     const module = specifier.substring(specifier.indexOf('/') + 1);
 
-    if (isEslintConfigFromAFullyQualifiedModuleName(module, prefix)) {
+    if (isLinterConfigFromAFullyQualifiedModuleName(module, prefix)) {
       return specifier;
     }
     return `${scope}/${prefix}${module}`;
   }
-  if (isEslintConfigFromAFullyQualifiedModuleName(specifier, prefix)) {
+  if (isLinterConfigFromAFullyQualifiedModuleName(specifier, prefix)) {
     return specifier;
   }
   return `${prefix}${specifier}`;
@@ -99,13 +99,13 @@
   }
 }
 
-function checkConfig(config, rootDir) {
+function checkConfig(flavour, config, rootDir) {
   const parser = wrapToArray(config.parser);
-  const plugins = wrapToArray(config.plugins).map(plugin => `eslint-plugin-${plugin}`);
+  const plugins = wrapToArray(config.plugins).map(plugin => `${flavour}-plugin-${plugin}`);
 
   const presets = wrapToArray(config.extends)
-    .filter(preset => preset !== 'eslint:recommended')
-    .map(preset => resolvePresetPackage(preset, rootDir));
+    .filter(preset => preset !== `${flavour}:recommended`)
+    .map(preset => resolvePresetPackage(flavour, preset, rootDir));
 
   const presetPackages = presets
     .filter(preset => !path.isAbsolute(preset))
@@ -113,18 +113,19 @@
 
   const presetDeps = lodash(presets)
     .map(preset => loadConfig(preset, rootDir))
-    .map(presetConfig => checkConfig(presetConfig, rootDir))
+    .map(presetConfig => checkConfig(flavour, presetConfig, rootDir))
     .flatten()
     .value();
 
   return lodash.union(parser, plugins, presetPackages, presetDeps);
 }
 
-export default function parseESLint(content, filename, deps, rootDir) {
+export default function parseLinter(flavour, content, filename, deps, rootDir) {
   const basename = path.basename(filename);
-  if (/^\.eslintrc(\.json|\.js|\.yml|\.yaml)?$/.test(basename)) {
+  const filenameRegex = new RegExp(`^\\.${flavour}rc(\\.json|\\.js|\\.yml|\\.yaml)?$`);
+  if (filenameRegex.test(basename)) {
     const config = parse(content);
-    return checkConfig(config, rootDir);
+    return checkConfig(flavour, config, rootDir);
   }
 
   return [];
```