### PR TITLE
Fix error when Typescript is not installed

### DIFF
--- a/src/parser/typescript.js
+++ b/src/parser/typescript.js
@@ -3,16 +3,16 @@ import { tryRequire } from '../utils';
 
 const typescript = tryRequire('typescript');
 
-const defaultCompileOptions = {
-  module: typescript.ModuleKind.CommonJS,
-  target: typescript.ScriptTarget.Latest,
-  jsx: typescript.JsxEmit.React,
-};
-
 export default function parseTypescript(content, filePath) {
   if (!typescript) {
     return [];
   }
+
+  const defaultCompileOptions = {
+    module: typescript.ModuleKind.CommonJS,
+    target: typescript.ScriptTarget.Latest,
+    jsx: typescript.JsxEmit.React,
+  };
 
   const result = typescript.transpile(
     content,


### PR DESCRIPTION
Fixes #280. The code was referencing the `typescript` object when it
is potentially `null`.

It's not included in this PR, but we could consider adding a check to
catch this situation in CI (filed as an issue in #281).