### PR TITLE
Add tests for esnext syntax in Typescript

### DIFF
--- a/test/fake_modules/typescript/esnext.ts
+++ b/test/fake_modules/typescript/esnext.ts
@@ -1,0 +1,8 @@
+import Dep from 'ts-dep-esnext';
+
+export const ObjRestSpread = () => {
+  const a = {a: 1, b: 2};
+  const { b, ...rest } = a;
+  const c = {...a, ...rest};
+  new Dep(c);
+}

--- a/test/fake_modules/typescript/package.json
+++ b/test/fake_modules/typescript/package.json
@@ -3,6 +3,7 @@
     "react": "0.0.1",
     "ts-dep-1": "0.0.1",
     "ts-dep-2": "0.0.1",
+    "ts-dep-esnext": "0.0.1",
     "unused-dep": "0.0.1"
   }
 }

--- a/test/spec.js
+++ b/test/spec.js
@@ -185,6 +185,7 @@ export default [
         react: ['component.tsx'],
         'ts-dep-1': ['index.ts'],
         'ts-dep-2': ['index.ts'],
+        'ts-dep-esnext': ['esnext.ts'],
       },
     },
   },


### PR DESCRIPTION
These tests cover the changes in PR #258 (they fail without PR #258).