### PR TITLE
use eslint name normalization

### DIFF
--- a/test/special/eslint.js
+++ b/test/special/eslint.js
@@ -22,10 +22,24 @@ const testCases = [
   {
     name: 'detect specific plugins',
     content: {
-      plugins: ['mocha'],
+      plugins: [
+        'mocha',
+        '@foo',
+        '@bar/eslint-plugin',
+        'baz',
+        'eslint-plugin-boo',
+        '@foo/bar',
+        '@baz\\eslint-plugin',
+      ],
     },
     expected: [
       'eslint-plugin-mocha',
+      '@foo/eslint-plugin',
+      '@bar/eslint-plugin',
+      'eslint-plugin-baz',
+      'eslint-plugin-boo',
+      '@foo/eslint-plugin-bar',
+      '@baz/eslint-plugin',
     ],
   },
   {


### PR DESCRIPTION
It is possible in ESLint to have plugins in the following formats:

```json
[
  "@foo/eslint-plugin",
  "@foo",
  "bar",
  "eslint-plugin-bar"
]
```

We currently only support the last two in depcheck, which leads to some freaky errors:

```
Missing dependencies: { 'eslint-plugin-@typescript-eslint/eslint-plugin':
```

I took the function as-is from eslint and left a jsdoc link to it.