### PR TITLE
correct resolution of lint `extends` packages

### DIFF
--- a/src/special/eslint.js
+++ b/src/special/eslint.js
@@ -1,5 +1,112 @@
-import parseLinter from '../utils/linters';
+import path from 'path';
+import lodash from 'lodash';
+import requirePackageName from 'require-package-name';
+import { wrapToArray } from '../utils/index';
+import { loadConfig } from '../utils/linters';
+
+function requireConfig(preset, rootDir) {
+  const presetPath = path.isAbsolute(preset)
+    ? preset
+    : path.resolve(rootDir, 'node_modules', preset);
+
+  try {
+    return require(presetPath); // eslint-disable-line global-require
+  } catch (error) {
+    return {}; // silently return nothing
+  }
+}
+
+/**
+ * Brings package name to correct format based on prefix
+ * @param {string} name The name of the package.
+ * @param {string} prefix Can be either "eslint-plugin", "eslint-config" or "eslint-formatter"
+ * @returns {string} Normalized name of the package
+ * @private
+ * @see {@link https://github.com/eslint/eslint/blob/faf3c4eda0d27323630d0bc103a99dd0ecffe842/lib/util/naming.js#L25 ESLint}
+ */
+function normalizePackageName(name, prefix) {
+  let normalizedName = name;
+  const convertPathToPosix = p => path.normalize(p).replace(/\\/g, '/');
+
+  /**
+   * On Windows, name can come in with Windows slashes instead of Unix slashes.
+   * Normalize to Unix first to avoid errors later on.
+   * https://github.com/eslint/eslint/issues/5644
+   */
+  if (normalizedName.indexOf('\\') > -1) {
+    normalizedName = convertPathToPosix(normalizedName);
+  }
+
+  if (normalizedName.charAt(0) === '@') {
+    /**
+     * it's a scoped package
+     * package name is the prefix, or just a username
+     */
+    const scopedPackageShortcutRegex = new RegExp(`^(@[^/]+)(?:/(?:${prefix})?)?$`);
+    const scopedPackageNameRegex = new RegExp(`^${prefix}(-|$)`);
+
+    if (scopedPackageShortcutRegex.test(normalizedName)) {
+      normalizedName = normalizedName
+        .replace(scopedPackageShortcutRegex, `$1/${prefix}`);
+    } else if (!scopedPackageNameRegex.test(normalizedName.split('/')[1])) {
+      /**
+       * for scoped packages, insert the prefix after the first / unless
+       * the path is already @scope/eslint or @scope/eslint-xxx-yyy
+       */
+      normalizedName = normalizedName
+        .replace(/^@([^/]+)\/(.*)$/, `@$1/${prefix}-$2`);
+    }
+  } else if (normalizedName.indexOf(`${prefix}-`) !== 0) {
+    normalizedName = `${prefix}-${normalizedName}`;
+  }
+
+  return normalizedName;
+}
+
+function resolvePresetPackage(preset, rootDir) {
+  // inspired from https://github.com/eslint/eslint/blob/5b4a94e26d0ef247fe222dacab5749805d9780dd/lib/config/config-file.js#L347
+  if (path.isAbsolute(preset)) {
+    return preset;
+  }
+  if (preset.startsWith('./') || preset.startsWith('../')) {
+    return path.resolve(rootDir, preset);
+  }
+
+  if (preset.startsWith('plugin:')) {
+    const pluginName = preset.slice(7, preset.lastIndexOf('/'));
+    return normalizePackageName(pluginName, 'eslint-plugin');
+  }
+
+  return normalizePackageName(preset, 'eslint-config');
+}
+
+function checkConfig(config, rootDir) {
+  const parser = wrapToArray(config.parser);
+  const plugins = wrapToArray(config.plugins)
+    .map(plugin => normalizePackageName(plugin, 'eslint-plugin'));
+
+  const presets = wrapToArray(config.extends)
+    .filter(preset => preset !== 'eslint:recommended')
+    .map(preset => resolvePresetPackage(preset, rootDir));
+
+  const presetPackages = presets
+    .filter(preset => !path.isAbsolute(preset))
+    .map(requirePackageName);
+
+  const presetDeps = lodash(presets)
+    .map(preset => requireConfig(preset, rootDir))
+    .map(presetConfig => checkConfig(presetConfig, rootDir))
+    .flatten()
+    .value();
+
+  return lodash.union(parser, plugins, presetPackages, presetDeps);
+}
 
 export default function parseESLint(content, filename, deps, rootDir) {
-  return parseLinter('eslint', content, filename, deps, rootDir);
+  const config = loadConfig('eslint', filename, content);
+  if (config) {
+    return checkConfig(config, rootDir);
+  }
+
+  return [];
 }

--- a/src/special/tslint.js
+++ b/src/special/tslint.js
@@ -18,6 +18,13 @@ function checkConfig(config, rootDir) {
     .map(requirePackageName);
 }
 
+/**
+ * Parses TSLint configuration for dependencies.
+ *
+ * TSLint uses node resolution to load inherited configurations.
+ * More info on this can be found
+ * [here](https://palantir.github.io/tslint/usage/configuration/).
+ */
 export default function parseTSLint(content, filename, deps, rootDir) {
   const config = loadConfig('tslint', filename, content);
   if (config) {

--- a/src/special/tslint.js
+++ b/src/special/tslint.js
@@ -1,5 +1,28 @@
-import parseLinter from '../utils/linters';
+import path from 'path';
+import requirePackageName from 'require-package-name';
+import { loadConfig } from '../utils/linters';
+import { wrapToArray } from '../utils/index';
+
+function resolvePresetPackage(preset, rootDir) {
+  if (preset.startsWith('./') || preset.startsWith('../')) {
+    return path.resolve(rootDir, preset);
+  }
+  return preset;
+}
+
+function checkConfig(config, rootDir) {
+  return wrapToArray(config.extends)
+    .filter(preset => !preset.startsWith('tslint:'))
+    .map(preset => resolvePresetPackage(preset, rootDir))
+    .filter(preset => !path.isAbsolute(preset))
+    .map(requirePackageName);
+}
 
 export default function parseTSLint(content, filename, deps, rootDir) {
-  return parseLinter('tslint', content, filename, deps, rootDir);
+  const config = loadConfig('tslint', filename, content);
+  if (config) {
+    return checkConfig(config, rootDir);
+  }
+
+  return [];
 }

--- a/src/utils/linters.js
+++ b/src/utils/linters.js
@@ -1,10 +1,8 @@
 import path from 'path';
 import yaml from 'js-yaml';
-import lodash from 'lodash';
-import requirePackageName from 'require-package-name';
-import { evaluate, wrapToArray } from '.';
+import { evaluate } from '.';
 
-function parse(content) {
+export function parse(content) {
   try {
     return JSON.parse(content);
   } catch (error) {
@@ -27,135 +25,14 @@ function parse(content) {
   return {};
 }
 
-function isLinterConfigAnAbsolutePath(specifier) {
-  return path.isAbsolute(specifier);
-}
 
-function isLinterConfigARelativePath(specifier) {
-  return lodash.startsWith(specifier, './') || lodash.startsWith(specifier, '../');
-}
-
-function isLinterConfigFromAPlugin(specifier) {
-  return lodash.startsWith(specifier, 'plugin:');
-}
-
-function isLinterConfigFromAScopedModule(specifier) {
-  return lodash.startsWith(specifier, '@');
-}
-
-function isLinterConfigFromAFullyQualifiedModuleName(specifier, prefix) {
-  return lodash.startsWith(specifier, prefix);
-}
-
-function resolvePresetPackage(flavour, preset, rootDir) {
-  if (flavour === 'tslint') {
-    return preset;
-  }
-
-  // inspired from https://github.com/eslint/eslint/blob/5b4a94e26d0ef247fe222dacab5749805d9780dd/lib/config/config-file.js#L347
-  if (isLinterConfigAnAbsolutePath(preset)) {
-    return preset;
-  }
-  if (isLinterConfigARelativePath(preset)) {
-    return path.resolve(rootDir, preset);
-  }
-
-  if (isLinterConfigFromAPlugin(preset)) {
-    const pluginName = preset.slice(7, preset.lastIndexOf('/'));
-    return normalizePackageName(pluginName, `${flavour}-plugin`);
-  }
-
-  return normalizePackageName(preset, `${flavour}-config`);
-}
-
-function loadConfig(preset, rootDir) {
-  const presetPath = path.isAbsolute(preset)
-    ? preset
-    : path.resolve(rootDir, 'node_modules', preset);
-
-  try {
-    return require(presetPath); // eslint-disable-line global-require
-  } catch (error) {
-    return {}; // silently return nothing
-  }
-}
-
-/**
- * Brings package name to correct format based on prefix
- * @param {string} name The name of the package.
- * @param {string} prefix Can be either "eslint-plugin", "eslint-config" or "eslint-formatter"
- * @returns {string} Normalized name of the package
- * @private
- * @see {@link https://github.com/eslint/eslint/blob/faf3c4eda0d27323630d0bc103a99dd0ecffe842/lib/util/naming.js#L25 ESLint}
- */
-function normalizePackageName(name, prefix) {
-  let normalizedName = name;
-  const convertPathToPosix = p => path.normalize(p).replace(/\\/g, '/');
-
-  /**
-   * On Windows, name can come in with Windows slashes instead of Unix slashes.
-   * Normalize to Unix first to avoid errors later on.
-   * https://github.com/eslint/eslint/issues/5644
-   */
-  if (normalizedName.indexOf('\\') > -1) {
-    normalizedName = convertPathToPosix(normalizedName);
-  }
-
-  if (normalizedName.charAt(0) === '@') {
-    /**
-     * it's a scoped package
-     * package name is the prefix, or just a username
-     */
-    const scopedPackageShortcutRegex = new RegExp(`^(@[^/]+)(?:/(?:${prefix})?)?$`);
-    const scopedPackageNameRegex = new RegExp(`^${prefix}(-|$)`);
-
-    if (scopedPackageShortcutRegex.test(normalizedName)) {
-      normalizedName = normalizedName
-        .replace(scopedPackageShortcutRegex, `$1/${prefix}`);
-    } else if (!scopedPackageNameRegex.test(normalizedName.split('/')[1])) {
-      /**
-       * for scoped packages, insert the prefix after the first / unless
-       * the path is already @scope/eslint or @scope/eslint-xxx-yyy
-       */
-      normalizedName = normalizedName
-        .replace(/^@([^/]+)\/(.*)$/, `@$1/${prefix}-$2`);
-    }
-  } else if (normalizedName.indexOf(`${prefix}-`) !== 0) {
-    normalizedName = `${prefix}-${normalizedName}`;
-  }
-
-  return normalizedName;
-}
-
-function checkConfig(flavour, config, rootDir) {
-  const parser = wrapToArray(config.parser);
-  const plugins = wrapToArray(config.plugins)
-    .map(plugin => normalizePackageName(plugin, `${flavour}-plugin`));
-
-  const presets = wrapToArray(config.extends)
-    .filter(preset => preset !== `${flavour}:recommended`)
-    .map(preset => resolvePresetPackage(flavour, preset, rootDir));
-
-  const presetPackages = presets
-    .filter(preset => !path.isAbsolute(preset))
-    .map(requirePackageName);
-
-  const presetDeps = lodash(presets)
-    .map(preset => loadConfig(preset, rootDir))
-    .map(presetConfig => checkConfig(flavour, presetConfig, rootDir))
-    .flatten()
-    .value();
-
-  return lodash.union(parser, plugins, presetPackages, presetDeps);
-}
-
-export default function parseLinter(flavour, content, filename, deps, rootDir) {
+export function loadConfig(flavour, filename, content) {
   const basename = path.basename(filename);
   const filenameRegex = new RegExp(`^\\.?${flavour}(rc)?(\\.json|\\.js|\\.yml|\\.yaml)?$`);
   if (filenameRegex.test(basename)) {
     const config = parse(content);
-    return checkConfig(flavour, config, rootDir);
+    return config;
   }
 
-  return [];
+  return null;
 }

--- a/src/utils/linters.js
+++ b/src/utils/linters.js
@@ -48,6 +48,10 @@ function isLinterConfigFromAFullyQualifiedModuleName(specifier, prefix) {
 }
 
 function resolvePresetPackage(flavour, preset, rootDir) {
+  if (flavour === 'tslint') {
+    return preset;
+  }
+
   // inspired from https://github.com/eslint/eslint/blob/5b4a94e26d0ef247fe222dacab5749805d9780dd/lib/config/config-file.js#L347
   if (isLinterConfigAnAbsolutePath(preset)) {
     return preset;

--- a/src/utils/linters.js
+++ b/src/utils/linters.js
@@ -56,25 +56,12 @@ function resolvePresetPackage(flavour, preset, rootDir) {
     return path.resolve(rootDir, preset);
   }
 
-  const { prefix, specifier } = (
-    isLinterConfigFromAPlugin(preset)
-      ? { prefix: `${flavour}-plugin-`, specifier: preset.substring(preset.indexOf(':') + 1) }
-      : { prefix: `${flavour}-config-`, specifier: preset }
-  );
-
-  if (isLinterConfigFromAScopedModule(specifier)) {
-    const scope = specifier.substring(0, specifier.indexOf('/'));
-    const module = specifier.substring(specifier.indexOf('/') + 1);
-
-    if (isLinterConfigFromAFullyQualifiedModuleName(module, prefix)) {
-      return specifier;
-    }
-    return `${scope}/${prefix}${module}`;
+  if (isLinterConfigFromAPlugin(preset)) {
+    const pluginName = preset.slice(7, preset.lastIndexOf('/'));
+    return normalizePackageName(pluginName, `${flavour}-plugin`);
   }
-  if (isLinterConfigFromAFullyQualifiedModuleName(specifier, prefix)) {
-    return specifier;
-  }
-  return `${prefix}${specifier}`;
+
+  return normalizePackageName(preset, `${flavour}-config`);
 }
 
 function loadConfig(preset, rootDir) {

--- a/test/special/eslint.js
+++ b/test/special/eslint.js
@@ -149,6 +149,15 @@ const testCases = [
   {
     name: 'handle config from scoped plugin with short name',
     content: {
+      extends: 'plugin:@my-org/recommended',
+    },
+    expected: [
+      '@my-org/eslint-plugin',
+    ],
+  },
+  {
+    name: 'handle config from scoped plugin with short name & config',
+    content: {
       extends: 'plugin:@my-org/short-customized/recommended',
     },
     expected: [

--- a/test/special/tslint.js
+++ b/test/special/tslint.js
@@ -11,18 +11,20 @@ const testCases = [
     expected: [],
   },
   {
-    name: 'detect specific plugins',
-    content: {
-      plugins: ['mocha'],
-    },
-    expected: [
-      'tslint-plugin-mocha',
-    ],
-  },
-  {
-    name: 'skip tslint recommended config',
+    name: 'skip single built-in config',
     content: {
       extends: 'tslint:recommended',
+    },
+    expected: [],
+  },
+  {
+    name: 'skip built-in configs',
+    content: {
+      extends: [
+        'tslint:recommended',
+        'tslint:latest',
+        'tslint:foo',
+      ],
     },
     expected: [],
   },
@@ -41,12 +43,25 @@ const testCases = [
     expected: [],
   },
   {
-    name: 'handle config of scoped module with full name',
+    name: 'handle config of module',
     content: {
-      extends: '@my-org/tslint-config-long-customized',
+      extends: 'some-module',
     },
     expected: [
-      '@my-org/tslint-config-long-customized',
+      'some-module',
+    ],
+  },
+  {
+    name: 'handle config of multiple modules',
+    content: {
+      extends: [
+        'some-module',
+        '@another/module',
+      ],
+    },
+    expected: [
+      'some-module',
+      '@another/module',
     ],
   },
 ];

--- a/test/special/tslint.js
+++ b/test/special/tslint.js
@@ -20,24 +20,6 @@ const testCases = [
     ],
   },
   {
-    name: 'handle tslint config with short name',
-    content: {
-      extends: 'preset',
-    },
-    expected: [
-      'tslint-config-preset',
-    ],
-  },
-  {
-    name: 'handle tslint config with full name',
-    content: {
-      extends: 'tslint-config-preset',
-    },
-    expected: [
-      'tslint-config-preset',
-    ],
-  },
-  {
     name: 'skip tslint recommended config',
     content: {
       extends: 'tslint:recommended',

--- a/test/special/tslint.js
+++ b/test/special/tslint.js
@@ -59,57 +59,12 @@ const testCases = [
     expected: [],
   },
   {
-    name: 'handle config of scoped module',
-    content: {
-      extends: '@my-org/short-customized',
-    },
-    expected: [
-      '@my-org/tslint-config-short-customized',
-    ],
-  },
-  {
     name: 'handle config of scoped module with full name',
     content: {
       extends: '@my-org/tslint-config-long-customized',
     },
     expected: [
       '@my-org/tslint-config-long-customized',
-    ],
-  },
-  {
-    name: 'handle config from plugin with short name',
-    content: {
-      extends: 'plugin:node/recommended',
-    },
-    expected: [
-      'tslint-plugin-node',
-    ],
-  },
-  {
-    name: 'handle config from plugin with full name',
-    content: {
-      extends: 'plugin:tslint-plugin-node/recommended',
-    },
-    expected: [
-      'tslint-plugin-node',
-    ],
-  },
-  {
-    name: 'handle config from scoped plugin with short name',
-    content: {
-      extends: 'plugin:@my-org/short-customized/recommended',
-    },
-    expected: [
-      '@my-org/tslint-plugin-short-customized',
-    ],
-  },
-  {
-    name: 'handle config from scoped plugin with full name',
-    content: {
-      extends: 'plugin:@my-org/tslint-plugin-long-customized/recommended',
-    },
-    expected: [
-      '@my-org/tslint-plugin-long-customized',
     ],
   },
 ];


### PR DESCRIPTION
There's currently a bug in master in that extending `plugin:@scope/name` should result in `@scope/eslint-plugin` but we incorrectly resolve it as `@scope/eslint-plugin-name` or some such thing.

In this PR, I have removed most of what logic we had around `extends` and (like ESLint does its self) have used the normalisation function I recently introduced.

I also removed a bunch TSLint tests, because TSLint only supports loading inherited configs by node resolution (it just does a `require` on it). Because of this, I had to add a short-circuit in the resolution function to return the path as-is for tslint.

cc @rumpl 