### PR TITLE
use file instead of content.

### DIFF
--- a/src/parser/sass.js
+++ b/src/parser/sass.js
@@ -8,7 +8,7 @@ const sass = tryRequire('node-sass');
 
 export default function parseSASS(content, filePath, deps, rootDir) {
   const { stats } = sass.renderSync({
-    data: content,
+    file: filePath,
     includePaths: [path.dirname(filePath)],
     importer: tildeImporter,
   });


### PR DESCRIPTION
Fixes false positive for characters in sass files that renderSync has issues parsing.

In node-sass
```  
if (options.data) {
    status = binding.renderSync(options);
  } else if (options.file) {
    status = binding.renderFileSync(options);
```

renderSync has issues with some characters and errors with:

```
  at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:408:3)
        status: 1,
        file: 'stdin',
        line: 1,
        column: 9,
        message: 'returned value of `file` must be a string',
        formatted: 'Error: returned value of `file` must be a string\n        on line 1 of stdin\n>> @import "~react-vis/dist/main.scss";\n\n   --------^\n' 
```

By changing it to read the file instead it avoids this issue.