### PR TITLE
bugfix: include tslint in deps when a tslintrc exists

### DIFF
--- a/src/special/eslint.js
+++ b/src/special/eslint.js
@@ -102,8 +102,10 @@ function checkConfig(config, rootDir) {
   return lodash.union(parser, plugins, presetPackages, presetDeps);
 }
 
+const configNameRegex = /^\.eslintrc(\.(json|js|yml|yaml))?$/;
+
 export default function parseESLint(content, filename, deps, rootDir) {
-  const config = loadConfig('eslint', filename, content);
+  const config = loadConfig(configNameRegex, filename, content);
   if (config) {
     return checkConfig(config, rootDir);
   }

--- a/src/special/tslint.js
+++ b/src/special/tslint.js
@@ -18,6 +18,8 @@ function checkConfig(config, rootDir) {
     .map(requirePackageName);
 }
 
+const configNameRegex = /^tslint\.(json|yaml|yml)$/;
+
 /**
  * Parses TSLint configuration for dependencies.
  *
@@ -26,7 +28,7 @@ function checkConfig(config, rootDir) {
  * [here](https://palantir.github.io/tslint/usage/configuration/).
  */
 export default function parseTSLint(content, filename, deps, rootDir) {
-  const config = loadConfig('tslint', filename, content);
+  const config = loadConfig(configNameRegex, filename, content);
   if (config) {
     return ['tslint', ...checkConfig(config, rootDir)];
   }

--- a/src/special/tslint.js
+++ b/src/special/tslint.js
@@ -28,7 +28,7 @@ function checkConfig(config, rootDir) {
 export default function parseTSLint(content, filename, deps, rootDir) {
   const config = loadConfig('tslint', filename, content);
   if (config) {
-    return checkConfig(config, rootDir);
+    return ['tslint', ...checkConfig(config, rootDir)];
   }
 
   return [];

--- a/src/utils/linters.js
+++ b/src/utils/linters.js
@@ -26,9 +26,8 @@ export function parse(content) {
 }
 
 
-export function loadConfig(flavour, filename, content) {
+export function loadConfig(filenameRegex, filename, content) {
   const basename = path.basename(filename);
-  const filenameRegex = new RegExp(`^\\.?${flavour}(rc)?(\\.json|\\.js|\\.yml|\\.yaml)?$`);
   if (filenameRegex.test(basename)) {
     const config = parse(content);
     return config;

--- a/test/special/tslint.js
+++ b/test/special/tslint.js
@@ -8,14 +8,14 @@ const testCases = [
   {
     name: 'ignore when user not extends any config in `.tslintrc`',
     content: {},
-    expected: [],
+    expected: ['tslint'],
   },
   {
     name: 'skip single built-in config',
     content: {
       extends: 'tslint:recommended',
     },
-    expected: [],
+    expected: ['tslint'],
   },
   {
     name: 'skip built-in configs',
@@ -26,21 +26,21 @@ const testCases = [
         'tslint:foo',
       ],
     },
-    expected: [],
+    expected: ['tslint'],
   },
   {
     name: 'handle config of absolute local path',
     content: {
       extends: '/path/to/config',
     },
-    expected: [],
+    expected: ['tslint'],
   },
   {
     name: 'handle config of relative local path',
     content: {
       extends: './config',
     },
-    expected: [],
+    expected: ['tslint'],
   },
   {
     name: 'handle config of module',
@@ -48,6 +48,7 @@ const testCases = [
       extends: 'some-module',
     },
     expected: [
+      'tslint',
       'some-module',
     ],
   },
@@ -60,6 +61,7 @@ const testCases = [
       ],
     },
     expected: [
+      'tslint',
       'some-module',
       '@another/module',
     ],
@@ -89,7 +91,7 @@ describe('tslint special parser', () => {
   });
 
   it('should handle parse error', () =>
-    testTslint([], '{ this is an invalid JSON string'));
+    testTslint(['tslint'], '{ this is an invalid JSON string'));
 
   it('should handle non-standard JSON content', () =>
     testTslint(

--- a/test/special/tslint.js
+++ b/test/special/tslint.js
@@ -6,7 +6,7 @@ import tslintSpecialParser from '../../src/special/tslint';
 
 const testCases = [
   {
-    name: 'ignore when user not extends any config in `.tslintrc`',
+    name: 'ignore when user not extends any config in `tslint.json`',
     content: {},
     expected: ['tslint'],
   },
@@ -70,11 +70,9 @@ const testCases = [
 
 function testTslint(deps, content) {
   [
-    '/path/to/.tslintrc',
-    '/path/to/.tslintrc.js',
-    '/path/to/.tslintrc.json',
-    '/path/to/.tslintrc.yml',
-    '/path/to/.tslintrc.yaml',
+    '/path/to/tslint.json',
+    '/path/to/tslint.yml',
+    '/path/to/tslint.yaml',
   ].forEach((pathToTslintrc) => {
     const result = tslintSpecialParser(
       content, pathToTslintrc, deps, __dirname,
@@ -85,7 +83,7 @@ function testTslint(deps, content) {
 }
 
 describe('tslint special parser', () => {
-  it('should ignore when filename is not `.tslintrc`', () => {
+  it('should ignore when filename is not `tslint.json`', () => {
     const result = tslintSpecialParser('content', '/a/file');
     result.should.deepEqual([]);
   });


### PR DESCRIPTION
This should fix part of a few issues like #319.

I introduced `tslint` as a dependency every time a `tslintrc` file exists. Let me know if you think this is reasonable (and also if its fine that we still expect it when the tslint config is invalid).