### PR TITLE
detector: allow template literals in require calls

### DIFF
--- a/src/detector/requireCallExpression.js
+++ b/src/detector/requireCallExpression.js
@@ -1,12 +1,20 @@
-import lodash from 'lodash';
-
 export default function requireCallExpression(node) {
-  return node.type === 'CallExpression'
+  if (node.type === 'CallExpression'
     && node.callee
     && node.callee.type === 'Identifier'
     && node.callee.name === 'require'
-    && node.arguments[0]
-    && lodash.isString(node.arguments[0].value)
-    ? [node.arguments[0].value]
-    : [];
+    && node.arguments.length === 1) {
+    if (node.arguments[0].type === 'Literal'
+      || node.arguments[0].type === 'StringLiteral') {
+      return typeof node.arguments[0].value === 'string'
+        ? [node.arguments[0].value] : [];
+    }
+
+    if (node.arguments[0].type === 'TemplateLiteral'
+      && node.arguments[0].quasis.length === 1
+      && node.arguments[0].expressions.length === 0) {
+      return [node.arguments[0].quasis[0].value.raw];
+    }
+  }
+  return [];
 }

--- a/test/fake_modules/good/index.js
+++ b/test/fake_modules/good/index.js
@@ -1,3 +1,5 @@
 /* eslint-disable no-unused-vars */
 
 const optimist = require('optimist');
+
+const foo = require(`foo`); // eslint-disable-line quotes

--- a/test/fake_modules/good/package.json
+++ b/test/fake_modules/good/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "optimist": "~0.6.0"
+    "optimist": "~0.6.0",
+    "foo": "^1.0.0"
   }
 }

--- a/test/spec.js
+++ b/test/spec.js
@@ -132,6 +132,7 @@ export default [
       missing: {},
       using: {
         optimist: ['index.js'],
+        foo: ['index.js'],
       },
     },
   },
@@ -459,6 +460,7 @@ export default [
       missing: {},
       using: {
         optimist: ['index.js'],
+        foo: ['index.js'],
       },
     },
   },


### PR DESCRIPTION
Fixes #243 

Only allows simple literals like:

```ts
require(`foo`); // fine
require(`foo${v}bar`); // ignore, no way to infer it, dont bother trying
```