### PR TITLE
fixed the inclusion syntax of babel plugins

### DIFF
--- a/src/parser/es7.js
+++ b/src/parser/es7.js
@@ -13,7 +13,7 @@ export default function parseES7(content) {
       'classProperties',
       'classPrivateProperties',
       'classPrivateMethods',
-      { decorators: { decoratorsBeforeExport: true } },
+      ['decorators', { decoratorsBeforeExport: true }],
       // not decorators-legacy
       'doExpressions',
       'dynamicImport',
@@ -28,7 +28,7 @@ export default function parseES7(content) {
       'objectRestSpread',
       'optionalCatchBinding',
       'optionalChaining',
-      { pipelineOperator: { proposal: 'minimal' } },
+      ['pipelineOperator', { proposal: 'minimal' }],
       'throwExpressions',
     ],
   });

--- a/src/parser/jsx.js
+++ b/src/parser/jsx.js
@@ -14,7 +14,7 @@ export default function parseJSX(content) {
       'classProperties',
       'classPrivateProperties',
       'classPrivateMethods',
-      { decorators: { decoratorsBeforeExport: true } },
+      ['decorators', { decoratorsBeforeExport: true }],
       // not decorators-legacy
       'doExpressions',
       'dynamicImport',
@@ -29,7 +29,7 @@ export default function parseJSX(content) {
       'objectRestSpread',
       'optionalCatchBinding',
       'optionalChaining',
-      { pipelineOperator: { proposal: 'minimal' } },
+      ['pipelineOperator', { proposal: 'minimal' }],
       'throwExpressions',
       // and finally, jsx
       'jsx'],


### PR DESCRIPTION
The old syntax lead to the plugins not being included