### PR TITLE
add babel plugins to vue special

### DIFF
--- a/src/parser/vue.js
+++ b/src/parser/vue.js
@@ -13,5 +13,35 @@ export default function parseVue(content) {
   }
   return parse(parsed.script.content, {
     sourceType: 'module',
+
+    // Enable all known compatible @babel/parser plugins at the time of writing.
+    // Because we only parse them, not evaluate any code, it is safe to do so.
+    // note that babel/parser 7+ does not support *, due to plugin incompatibilities
+    // Because the guys using React always want the newest syntax.
+    plugins: [
+      'asyncGenerators',
+      'bigInt',
+      'classProperties',
+      'classPrivateProperties',
+      'classPrivateMethods',
+      ['decorators', { decoratorsBeforeExport: true }],
+      // not decorators-legacy
+      'doExpressions',
+      'dynamicImport',
+      'exportDefaultFrom',
+      'exportNamespaceFrom',
+      'functionBind',
+      'functionSent',
+      'importMeta',
+      'logicalAssignment',
+      'nullishCoalescingOperator',
+      'numericSeparator',
+      'objectRestSpread',
+      'optionalCatchBinding',
+      'optionalChaining',
+      ['pipelineOperator', { proposal: 'minimal' }],
+      'throwExpressions',
+      // and finally, jsx
+      'jsx'],
   });
 }


### PR DESCRIPTION
Since they were missing so far :)

One thing to note about this:
It would probably be more flexible to use @babel/core.parseSync() instead of @babel/parser.parse(), because @babel/core implicitly looks for a babel.config.js and uses that for parsing. This way we don't have to brute force add all plugins to the config.