### PR TITLE
Allow process var access in linter configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "minimatch": "^3.0.2",
     "node-sass-tilde-importer": "^1.0.2",
     "please-upgrade-node": "^3.1.1",
+    "require-from-string": "^2.0.2",
     "require-package-name": "^2.0.1",
     "resolve": "^1.10.0",
     "walkdir": "0.0.12",

--- a/src/utils/linters.js
+++ b/src/utils/linters.js
@@ -1,7 +1,7 @@
 import yaml from 'js-yaml';
 import * as path from 'path';
 import * as fs from 'fs';
-import { evaluate } from '.';
+import requireFromString from 'require-from-string';
 import getScripts from './get-scripts';
 
 export function parse(content) {
@@ -18,7 +18,7 @@ export function parse(content) {
   }
 
   try {
-    return evaluate(`module.exports = ${content}`);
+    return requireFromString(`module.exports = ${content}`);
   } catch (error) {
     // not valid JavaScript code
   }

--- a/test/special/eslint.js
+++ b/test/special/eslint.js
@@ -208,6 +208,15 @@ describe('eslint special parser', () => {
       `${JSON.stringify(testCases[1].content)}\n// this is ignored`,
     ));
 
+  it('should work with process variable', () => {
+    const result = eslintSpecialParser(
+      'module.exports = { parser: \'babel-eslint\', rules: { \'no-console\': process.env.NODE_ENV == \'production\' ? 0 : 2 } }',
+      '/path/to/.eslintrc.js', ['babel-eslint'], __dirname,
+    );
+
+    result.should.deepEqual(['babel-eslint']);
+  })
+
   describe('with custom config', () => {
     it('should parse custom configs from scripts', () => {
       const rootDir = path.resolve(

--- a/test/special/eslint.js
+++ b/test/special/eslint.js
@@ -215,7 +215,7 @@ describe('eslint special parser', () => {
     );
 
     result.should.deepEqual(['babel-eslint']);
-  })
+  });
 
   describe('with custom config', () => {
     it('should parse custom configs from scripts', () => {

--- a/test/special/eslint.js
+++ b/test/special/eslint.js
@@ -210,7 +210,7 @@ describe('eslint special parser', () => {
 
   it('should work with process variable', () => {
     const result = eslintSpecialParser(
-      'module.exports = { parser: \'babel-eslint\', rules: { \'no-console\': process.env.NODE_ENV == \'production\' ? 0 : 2 } }',
+      'module.exports = { parser: \'babel-eslint\', rules: { \'no-console\': process.env.NODE_ENV == \'production\' ? 2 : 0 } }',
       '/path/to/.eslintrc.js', ['babel-eslint'], __dirname,
     );
 


### PR DESCRIPTION
The current evaluation function does not support Node.js features like process.env.NODE_ENV, which is helpful when e.g. defining configs that depend on the environment. This PR adds require-from-string, which supports these features.