### PR TITLE
Changes webpack regex to support 'webpack.conf.js'

### DIFF
--- a/src/special/webpack.js
+++ b/src/special/webpack.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import lodash from 'lodash';
 
-const webpackConfigRegex = /webpack(\..+)?\.config\.(babel\.)?js/;
+const webpackConfigRegex = /webpack(\..+)?\.conf(ig|)\.(babel\.)?js/;
 const loaderTemplates = ['*-webpack-loader', '*-web-loader', '*-loader', '*'];
 
 function extractLoaders(item) {

--- a/src/special/webpack.js
+++ b/src/special/webpack.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import lodash from 'lodash';
 
-const webpackConfigRegex = /webpack(\..+)?\.conf(ig|)\.(babel\.)?js/;
+const webpackConfigRegex = /webpack(\..+)?\.conf(?:ig|)\.(babel\.)?js/;
 const loaderTemplates = ['*-webpack-loader', '*-web-loader', '*-loader', '*'];
 
 function extractLoaders(item) {

--- a/test/special/webpack.js
+++ b/test/special/webpack.js
@@ -12,7 +12,7 @@ const configFileNames = [
   'webpack.config.babel.js',
   'webpack.prod.config.babel.js',
   'webpack.prod.conf.js',
-  'webpack.base.conf.babel.js
+  'webpack.base.conf.babel.js',
 ];
 
 const testCases = [

--- a/test/special/webpack.js
+++ b/test/special/webpack.js
@@ -11,6 +11,8 @@ const configFileNames = [
   'webpack.production.config.js',
   'webpack.config.babel.js',
   'webpack.prod.config.babel.js',
+  'webpack.prod.conf.js',
+  'webpack.base.conf.babel.js
 ];
 
 const testCases = [


### PR DESCRIPTION
The current webpack regex is `/webpack(\..+)?\.config\.(babel\.)?js/` which fails for `webpack.base.conf.js`. 

Although it's debatable whether or not `conf` over `config` is that common, that's how the project I work on  has the files set up. The regex change is fairly minimal, so I figure might as well make a PR and see.