### PR TITLE
Extract base package names for webpack

### DIFF
--- a/src/special/webpack.js
+++ b/src/special/webpack.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import lodash from 'lodash';
-import requirePackageName from 'require-package-name'
+import requirePackageName from 'require-package-name';
 
 const webpackConfigRegex = /webpack(\..+)?\.config\.(babel\.)?js/;
 const loaderTemplates = ['*-webpack-loader', '*-web-loader', '*-loader', '*'];

--- a/src/special/webpack.js
+++ b/src/special/webpack.js
@@ -1,16 +1,17 @@
 import path from 'path';
 import lodash from 'lodash';
+import requirePackageName from 'require-package-name'
 
 const webpackConfigRegex = /webpack(\..+)?\.config\.(babel\.)?js/;
 const loaderTemplates = ['*-webpack-loader', '*-web-loader', '*-loader', '*'];
 
 function extractLoaders(item) {
   if (typeof item === 'string') {
-    return item;
+    return requirePackageName(item) || item;
   }
 
   if (item.loader && typeof item.loader === 'string') {
-    return item.loader.split('!');
+    return item.loader.split('!').map(extractLoaders);
   }
 
   if (item.loaders) {


### PR DESCRIPTION
Currently the webpack special takes the full loader string as a package name. In fact, one can also pass subpackages like 'linaria/loader' as loaders. This PR uses require-package-name to extract the base package name out of the strings.