### PR TITLE
Fixing Issue #200: packages with bin that haven't been detected

### DIFF
--- a/src/special/bin.js
+++ b/src/special/bin.js
@@ -40,9 +40,18 @@ function getBinaryFeatures(dep, [key, value]) {
   return features;
 }
 
-function isBinaryInUse(dep, scripts, dir) {
+function getBinaries(dep, dir) {
   const metadata = loadMetadata(dep, dir);
-  const binaries = lodash.toPairs(metadata.bin || {});
+
+  if (typeof metadata.bin === 'string') {
+    return [[dep, metadata.bin]];
+  }
+
+  return lodash.toPairs(metadata.bin || {});
+}
+
+function isBinaryInUse(dep, scripts, dir) {
+  const binaries = getBinaries(dep, dir);
   return binaries.some(bin =>
     getBinaryFeatures(dep, bin).some(feature =>
       scripts.some(script =>

--- a/test/special/bin.js
+++ b/test/special/bin.js
@@ -82,6 +82,12 @@ const testCases = [
     dependencies: ['binary-package'],
     expected: ['binary-package'],
   },
+  {
+    name: 'detect packages with single binary',
+    script: 'single-binary-package --argument',
+    dependencies: ['single-binary-package'],
+    expected: ['single-binary-package'],
+  },
 ];
 
 function testParser(testCase, content, filename) {

--- a/test/special/node_modules/single-binary-package/package.json
+++ b/test/special/node_modules/single-binary-package/package.json
@@ -1,0 +1,3 @@
+{
+  "bin": "./bin/binary-exe"
+}


### PR DESCRIPTION
Some packages have a string of a single binary file instead of an object with the names of the binaries. This caused depcheck to declare those packages as missed. (Issue #200)