### PR TITLE
fix: Fix vue integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1618,8 +1618,7 @@
     "de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
-      "dev": true
+      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0="
     },
     "debug": {
       "version": "4.1.1",
@@ -3560,10 +3559,9 @@
       }
     },
     "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -7074,7 +7072,6 @@
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz",
       "integrity": "sha512-jVZkw4/I/HT5ZMvRnhv78okGusqe0+qH2A0Em0Cp8aq78+NK9TII263CDVz2QXZsIT+yyV/gZc/j/vlwa+Epyg==",
-      "dev": true,
       "requires": {
         "de-indent": "^1.0.2",
         "he": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "please-upgrade-node": "^3.1.1",
     "require-package-name": "^2.0.1",
     "resolve": "^1.10.0",
+    "vue-template-compiler": "^2.6.10",
     "walkdir": "^0.3.2",
     "yargs": "^13.2.2"
   },
@@ -87,8 +88,7 @@
     "patch-version": "^0.1.1",
     "proxyquire": "^2.1.0",
     "should": "^13.2.3",
-    "typescript": "^3.0.1",
-    "vue-template-compiler": "^2.5.16"
+    "typescript": "^3.0.1"
   },
   "nyc": {
     "sourceMap": false,


### PR DESCRIPTION
vue-template-compiler was in the devDependencies and didn't end up in
the released artifact giving way to weird unused dependencies issues

Fixes #361