### PR TITLE
support flow syntax in es7 and jsx parsers

### DIFF
--- a/src/parser/es7.js
+++ b/src/parser/es7.js
@@ -19,6 +19,8 @@ export default function parseES7(content) {
       'dynamicImport',
       'exportDefaultFrom',
       'exportNamespaceFrom',
+      'flow',
+      'flowComments',
       'functionBind',
       'functionSent',
       'importMeta',

--- a/src/parser/jsx.js
+++ b/src/parser/jsx.js
@@ -20,6 +20,8 @@ export default function parseJSX(content) {
       'dynamicImport',
       'exportDefaultFrom',
       'exportNamespaceFrom',
+      'flow',
+      'flowComments',
       'functionBind',
       'functionSent',
       'importMeta',

--- a/test/fake_modules/good_es7_flow/index.js
+++ b/test/fake_modules/good_es7_flow/index.js
@@ -1,0 +1,23 @@
+// @flow
+/* eslint-disable no-unused-vars */
+
+// This file includes some experimental ES7 syntax enabled in Babel by default. Reference: https://babeljs.io/docs/usage/experimental/
+
+import 'ecmascript-rest-spread';
+
+type TestType = {
+  x: Number,
+  y: Number,
+  x: Number,
+};
+
+const test: TestType = {
+  x: 1,
+  y: 2,
+  z: 3,
+};
+
+const objectRestSpread = {
+  ...test,
+  spec: 'https://github.com/sebmarkbage/ecmascript-rest-spread',
+};

--- a/test/fake_modules/good_es7_flow/package.json
+++ b/test/fake_modules/good_es7_flow/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "ecmascript-rest-spread": "0.0.1"
+  }
+}

--- a/test/fake_modules/jsx_flow/index.jsx
+++ b/test/fake_modules/jsx_flow/index.jsx
@@ -1,0 +1,9 @@
+// @flow
+var React = require('react');
+
+type Props = {
+  text: string
+};
+
+export default ({ text }: Props) =>
+  (<div>{text}</div>);

--- a/test/fake_modules/jsx_flow/package.json
+++ b/test/fake_modules/jsx_flow/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "react": "0.0.1"
+  }
+}

--- a/test/spec.js
+++ b/test/spec.js
@@ -197,6 +197,21 @@ export default [
     },
   },
   {
+    name: 'support flow syntax in ES7 modules',
+    module: 'good_es7_flow',
+    options: {
+      withoutDev: true,
+    },
+    expected: {
+      dependencies: [],
+      devDependencies: [],
+      missing: {},
+      using: {
+        'ecmascript-rest-spread': ['index.js'],
+      },
+    },
+  },
+  {
     name: 'support Typescript syntax',
     module: 'typescript',
     options: {
@@ -597,6 +612,20 @@ export default [
   {
     name: 'support jsx syntax',
     module: 'jsx',
+    options: {
+    },
+    expected: {
+      dependencies: [],
+      devDependencies: [],
+      missing: {},
+      using: {
+        react: ['index.jsx'],
+      },
+    },
+  },
+  {
+    name: 'support flow syntax in jsx modules',
+    module: 'jsx_flow',
     options: {
     },
     expected: {


### PR DESCRIPTION
resolves #353 
This PR adds babel's flow parsing to es7 and jsx parsers.