### PR TITLE
Make vue-template-compiler require more flexible

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "builtin-modules": "^3.0.0",
     "deprecate": "^1.0.0",
     "deps-regex": "^0.1.4",
+    "import-from": "^3.0.0",
     "js-yaml": "^3.4.2",
     "lodash": "^4.17.11",
     "minimatch": "^3.0.2",

--- a/src/parser/vue.js
+++ b/src/parser/vue.js
@@ -1,7 +1,8 @@
 import { parse } from '@babel/parser';
+import importFrom from 'import-from';
 import { tryRequire } from '../utils';
 
-const compiler = tryRequire('vue-template-compiler');
+const compiler = importFrom(process.cwd(), 'vue-template-compiler') || tryRequire('vue-template-compiler');
 
 export default function parseVue(content) {
   if (!compiler) {


### PR DESCRIPTION
I have depcheck included in a 3rd party CLI tool that builds other projects. This means that vue-template-compiler is not included in the same project as depcheck. This PR makes the require of vue-template-compiler more flexible and also checks for existence in process.cwd().