### PR TITLE
Use babel on typescript and support @types

### DIFF
--- a/false-alert.js
+++ b/false-alert.js
@@ -1,13 +1,15 @@
 /**
- * I am using this file to avoid false alert in this project.
- * It is not good, however it works.
- * The typescript and node-sass are parsers as peer dependencies.
- * However, because of NPM's bug, it is blocking users.
- * They are only mentioned in README and declared in devDependencies for testing.
- * Reference: https://github.com/depcheck/depcheck/issues/130
+ * This file exists to help avoid false alerts when running depcheck on itself
+ * as a build step, particularly in CI.
+ */
+
+/**
+ * These packages are used as optional peer dependencies
+ * Because of inconsistenties in npm behavior over time, depcheck
+ * cannot model the way these deps are required or used.
+ * For more information: https://github.com/depcheck/depcheck/issues/130
  */
 import 'node-sass';
-import 'typescript';
 import 'vue-template-compiler';
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -7115,12 +7115,6 @@
         "prelude-ls": "~1.1.2"
       }
     },
-    "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
-      "dev": true
-    },
     "uglify-js": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -87,8 +87,7 @@
     "nyc": "^14.1.0",
     "patch-version": "^0.1.1",
     "proxyquire": "^2.1.0",
-    "should": "^13.2.3",
-    "typescript": "^3.0.1"
+    "should": "^13.2.3"
   },
   "nyc": {
     "sourceMap": false,

--- a/src/component.json
+++ b/src/component.json
@@ -16,7 +16,8 @@
     "importCallExpression",
     "importDeclaration",
     "requireCallExpression",
-    "requireResolveCallExpression"
+    "requireResolveCallExpression",
+    "typescriptImportEqualsDeclaration"
   ],
   "special": [
     "eslint",

--- a/src/constants.js
+++ b/src/constants.js
@@ -49,6 +49,7 @@ export const defaultOptions = {
     availableDetectors.exportDeclaration,
     availableDetectors.requireCallExpression,
     availableDetectors.requireResolveCallExpression,
+    availableDetectors.typescriptImportEqualsDeclaration,
     availableDetectors.importCallExpression,
     availableDetectors.gruntLoadTaskCallExpression,
   ],

--- a/src/detector/typescriptImportEqualsDeclaration.js
+++ b/src/detector/typescriptImportEqualsDeclaration.js
@@ -1,0 +1,7 @@
+export default function detectTypescriptImportEqualsDeclaration(node) {
+  return node.type === 'TSImportEqualsDeclaration'
+    && node.moduleReference
+    && node.moduleReference.expression
+    ? [node.moduleReference.expression.value]
+    : [];
+}

--- a/src/parser/typescript.js
+++ b/src/parser/typescript.js
@@ -1,33 +1,14 @@
 import { parse } from '@babel/parser';
-import { tryRequire } from '../utils';
 
-const typescript = tryRequire('typescript');
-
-export default function parseTypescript(content, filePath) {
-  if (!typescript) {
-    return [];
-  }
-
-  const defaultCompileOptions = {
-    module: typescript.ModuleKind.CommonJS,
-    target: typescript.ScriptTarget.Latest,
-    jsx: typescript.JsxEmit.React,
-  };
-
-  const result = typescript.transpile(
-    content,
-    defaultCompileOptions,
-    filePath,
-  );
-
-  // TODO avoid parse source file twice, use Typescript native traverser to find out dependencies.
-  // Reference: https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#traversing-the-ast-with-a-little-linter
+export default function parseTypescript(content) {
   // Enable all known compatible @babel/parser plugins at the time of writing.
   // Because we only parse them, not evaluate any code, it is safe to do so.
   // note that babel/parser 7+ does not support *, due to plugin incompatibilities
-  return parse(result, {
+  return parse(content, {
     sourceType: 'module',
     plugins: [
+      'typescript',
+      'jsx',
       'asyncGenerators',
       'bigInt',
       'classProperties',

--- a/src/utils/typescript.js
+++ b/src/utils/typescript.js
@@ -1,0 +1,10 @@
+/* eslint-disable import/prefer-default-export */
+const orgDepRegex = /@(.*?)\/(.*)/;
+
+// The name of the DefinitelyTyped package for a given package
+export function getAtTypesName(dep) {
+  const match = orgDepRegex.exec(dep);
+  const pkgName = match ? `${match[1]}__${match[2]}` : dep;
+
+  return `@types/${pkgName}`;
+}

--- a/test/fake_modules/typescript/esnext.ts
+++ b/test/fake_modules/typescript/esnext.ts
@@ -1,4 +1,5 @@
 import Dep from 'ts-dep-esnext';
+import '@org/org-pkg';
 
 export const ObjRestSpread = () => {
   const a = {a: 1, b: 2};

--- a/test/fake_modules/typescript/package.json
+++ b/test/fake_modules/typescript/package.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
+    "@org/org-pkg": "0.0.1",
+    "@types/org__org-pkg": "0.0.1",
+    "@types/react": "0.0.1",
     "react": "0.0.1",
     "ts-dep-1": "0.0.1",
     "ts-dep-2": "0.0.1",

--- a/test/fake_modules/typescript/package.json
+++ b/test/fake_modules/typescript/package.json
@@ -4,6 +4,7 @@
     "ts-dep-1": "0.0.1",
     "ts-dep-2": "0.0.1",
     "ts-dep-esnext": "0.0.1",
+    "ts-dep-typedef": "0.0.1",
     "unused-dep": "0.0.1"
   }
 }

--- a/test/fake_modules/typescript/typedef.d.ts
+++ b/test/fake_modules/typescript/typedef.d.ts
@@ -1,0 +1,1 @@
+import 'ts-dep-typedef';

--- a/test/spec.js
+++ b/test/spec.js
@@ -225,6 +225,7 @@ export default [
         'ts-dep-1': ['index.ts'],
         'ts-dep-2': ['index.ts'],
         'ts-dep-esnext': ['esnext.ts'],
+        'ts-dep-typedef': ['typedef.d.ts'],
       },
     },
   },

--- a/test/spec.js
+++ b/test/spec.js
@@ -222,6 +222,9 @@ export default [
       missing: {},
       using: {
         react: ['component.tsx'],
+        '@types/react': ['component.tsx'],
+        '@types/org__org-pkg': ['esnext.ts'],
+        '@org/org-pkg': ['esnext.ts'],
         'ts-dep-1': ['index.ts'],
         'ts-dep-2': ['index.ts'],
         'ts-dep-esnext': ['esnext.ts'],


### PR DESCRIPTION
Surprisingly easy, in fact! Much, much easier than trying to work with typescript's barely-supported traversal API.

Fixes #421, #359, #163
