### PR TITLE
Add support for babel 7's scoped plugins

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,10 @@
 {
   "plugins": [
-    "babel-plugin-add-module-exports",
-    "@babel/plugin-transform-object-assign"
+    "add-module-exports",
+    "@babel/transform-object-assign"
   ],
   "presets": [
-    ["@babel/preset-env", {
+    ["@babel/env", {
       "targets": {
         "node": "6"
       }
@@ -13,7 +13,7 @@
   "env": {
     "test": {
       "plugins": [
-        "babel-plugin-istanbul"
+        "istanbul"
       ]
     }
   }

--- a/src/special/babel.js
+++ b/src/special/babel.js
@@ -60,7 +60,7 @@ function filter(deps, options) {
 
   const reactTransforms = getReactTransforms(deps, options.plugins);
 
-  return presets.concat(presets7, plugins, plugins7, reactTransforms);
+  return lodash.uniq(presets.concat(presets7, plugins, plugins7, reactTransforms));
 }
 
 function checkOptions(deps, options = {}) {

--- a/src/special/babel.js
+++ b/src/special/babel.js
@@ -15,7 +15,7 @@ function isPlugin(target, plugin) {
     : target[0] === plugin || target[0] === `babel-plugin-${plugin}`;
 }
 
-function contain(array, dep, prefix) {
+function contain(array, dep, prefix, scope) {
   if (!array) {
     return false;
   }
@@ -26,8 +26,11 @@ function contain(array, dep, prefix) {
     return true;
   }
 
-  if (prefix && dep.indexOf(prefix) === 0) {
-    return contain(array, dep.substring(prefix.length), false);
+  const fullPrefix = scope ? `${scope}/${prefix}` : prefix;
+
+  if (prefix && dep.indexOf(fullPrefix) === 0) {
+    const identifier = dep.substring(fullPrefix.length);
+    return contain(array, scope ? `${scope}/${identifier}` : identifier, false);
   }
 
   return false;
@@ -46,12 +49,18 @@ function filter(deps, options) {
   const presets = deps.filter((dep) =>
     contain(options.presets, dep, 'babel-preset-'));
 
+  const presets7 = deps.filter((dep) =>
+    contain(options.presets, dep, 'preset-', '@babel'));
+
   const plugins = deps.filter((dep) =>
     contain(options.plugins, dep, 'babel-plugin-'));
 
+  const plugins7 = deps.filter((dep) =>
+    contain(options.plugins, dep, 'plugin-', '@babel'));
+
   const reactTransforms = getReactTransforms(deps, options.plugins);
 
-  return presets.concat(plugins, reactTransforms);
+  return presets.concat(presets7, plugins, plugins7, reactTransforms);
 }
 
 function checkOptions(deps, options = {}) {

--- a/test/special/babel.js
+++ b/test/special/babel.js
@@ -38,6 +38,34 @@ const testCases = [
     },
   },
   {
+    name: 'recognize the scoped short-name plugin',
+    deps: ['@babel/plugin-syntax-jsx'],
+    options: {
+      plugins: ['@babel/syntax-jsx'],
+    },
+  },
+  {
+    name: 'recognize the scoped long-name plugin',
+    deps: ['@babel/plugin-syntax-jsx'],
+    options: {
+      plugins: ['@babel/plugin-syntax-jsx'],
+    },
+  },
+  {
+    name: 'recognize the scoped short-name preset',
+    deps: ['@babel/preset-es2015'],
+    options: {
+      presets: ['@babel/es2015'],
+    },
+  },
+  {
+    name: 'recognize the scoped long-name preset',
+    deps: ['@babel/preset-es2015'],
+    options: {
+      presets: ['@babel/preset-es2015'],
+    },
+  },
+  {
     name: 'recognize plugin specified with options',
     deps: ['babel-plugin-transform-async-to-module-method'],
     options: {
@@ -98,11 +126,11 @@ describe('babel special parser', () => {
     result.should.deepEqual(['babel-preset-es2015']);
   });
 
-  testCases.forEach(testCase =>
+  testCases.forEach((testCase) =>
     it(`should ${testCase.name} in .babelrc file`, () =>
       testBabel('.babelrc', testCase.deps, testCase.options)));
 
-  testCases.forEach(testCase =>
+  testCases.forEach((testCase) =>
     it(`should ${testCase.name} inside .babelrc file env section`, () =>
       testBabel('.babelrc', testCase.deps, {
         env: {
@@ -110,7 +138,7 @@ describe('babel special parser', () => {
         },
       })));
 
-  testCases.forEach(testCase =>
+  testCases.forEach((testCase) =>
     it(`should ${testCase.name} in package.json file`, () =>
       testBabel('package.json', testCase.deps, {
         name: 'my-package',
@@ -118,7 +146,7 @@ describe('babel special parser', () => {
         babel: testCase.options,
       })));
 
-  testCases.forEach(testCase =>
+  testCases.forEach((testCase) =>
     it(`should ${testCase.name} inside package.json file env section`, () =>
       testBabel('package.json', testCase.deps, {
         name: 'my-package',


### PR DESCRIPTION
Currently, you need to use the full preset or plugin name like `@babel/preset-env`.

This enables the short notation like `@babel/env` that already works similarly for older Babel versions (`babel-preset-env` => `env`).