### PR TITLE
Drop support for node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: node_js
 
 node_js:
-  - 8
   - 10
   - 12
 
@@ -31,7 +30,7 @@ deploy:
       secure: PwEt5+Vgf1Klas8rB1arAF/5zjIGMkP6NekNHkKhJXDwQkY3g19p3ORXnwOk4oRg3ggf3FO1CI7uh/fJb7nnfVMYc+X1Db1MoYgVQAWBS5L723VgLQ8I2BRHNie7CRmXywMUIV4E/8RYGeH/4b6jlY6gKNx3gnjeSeSjKyKl+OQ=
     on:
       tags: true
-      node: 8
+      node: 10
   - provider: releases
     skip_cleanup: true
     api_key:
@@ -39,4 +38,4 @@ deploy:
     draft: true
     on:
       tags: true
-      node: 8
+      node: 10

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,7 @@
 environment:
   matrix:
-  - nodejs_version: 8
-  - nodejs_version: 10
-  - nodejs_version: 12
+    - nodejs_version: 10
+    - nodejs_version: 12
 
 install:
   - cmd: git config core.symlinks true


### PR DESCRIPTION
End of life for node 8 is December 31 2019, which is, like, tomorrow, we
can safely remove support for it.