### PR TITLE
feat: detect when ran as a lifecycle event

### DIFF
--- a/src/special/npm-scripts.js
+++ b/src/special/npm-scripts.js
@@ -1,0 +1,12 @@
+import * as path from 'path';
+
+export default function parseNpmScripts(_, filename) {
+  const basename = path.basename(filename);
+
+  if (basename === 'package.json') {
+    const event = process.env.npm_lifecycle_event;
+    return event ? [event] : [];
+  }
+
+  return [];
+}

--- a/test/special/npm-scripts.js
+++ b/test/special/npm-scripts.js
@@ -1,0 +1,30 @@
+/* global describe, it */
+
+import 'should';
+import parse from '../../src/special/npm-scirpts';
+
+describe('npm scripts special parser', () => {
+  it('should ignore when not a lifecylce event', () => {
+    const lifecycle = process.env.npm_lifecycle_event;
+    delete process.env.npm_lifecycle_event;
+    const result = parse('content', '/path/to/package.json');
+    process.env.npm_lifecycle_event = lifecycle;
+    result.should.deepEqual([]);
+  });
+
+  it('should ignore when not a package.json', () => {
+    const lifecycle = process.env.npm_lifecycle_event;
+    delete process.env.npm_lifecycle_event;
+    const result = parse('content', '/path/to/package.json');
+    process.env.npm_lifecycle_event = lifecycle;
+    result.should.deepEqual([]);
+  });
+
+  it('should detect current npm lifecycle event', () => {
+    const expected = ['depcheck'];
+    const content = JSON.stringify({});
+    process.env.npm_lifecycle_event = 'depcheck';
+    const actual = parse(content, '/path/to/package.json');
+    actual.should.deepEqual(expected);
+  });
+});


### PR DESCRIPTION
When a command is ran with yarn (like yarn depcheck), we shouldn't
output it as an unused dependency.

Closes #460