### PR TITLE
Support prettier shared configuration

### DIFF
--- a/src/special/prettier.js
+++ b/src/special/prettier.js
@@ -1,0 +1,13 @@
+import path from 'path';
+import { readJSON } from '../utils';
+
+export default function parsePrettier(content, filepath) {
+  const filename = path.basename(filepath);
+  if (filename === 'package.json') {
+    const config = readJSON(filepath);
+    if (config && config.prettier && typeof config.prettier === 'string') {
+      return [config.prettier];
+    }
+  }
+  return [];
+}

--- a/test/fake_modules/prettier/package.json
+++ b/test/fake_modules/prettier/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "my-cool-library",
+  "version": "9000.0.1",
+  "prettier": "@company/prettier-config"
+}

--- a/test/special/prettier.js
+++ b/test/special/prettier.js
@@ -1,0 +1,33 @@
+/* global describe, it */
+
+import 'should';
+import fs from 'fs';
+import path from 'path';
+import parse from '../../src/special/prettier';
+
+function testPrettier(moduleName, fileName, expectedDeps) {
+  const rootDir = path.resolve(__dirname, '../fake_modules', moduleName);
+  const content = fs.readFileSync(
+    path.resolve(rootDir, 'package.json'),
+    'utf8',
+  );
+  const deps = ['dummy', '@company/prettier-config'];
+  const result = parse(content, path.resolve(rootDir, fileName), deps, rootDir);
+  Array.from(result).should.deepEqual(expectedDeps);
+}
+
+describe('prettier special parser', () => {
+  it('should ignore when filename is not supported', () => {
+    return testPrettier('prettier', 'not-supported.txt', []);
+  });
+
+  it('should not find anything if no prettier entry', () => {
+    return testPrettier('good', 'package.json', []);
+  });
+
+  it('should find prettier dependency if defined', () => {
+    return testPrettier('prettier', 'package.json', [
+      '@company/prettier-config',
+    ]);
+  });
+});


### PR DESCRIPTION
It is possible to define a prettier entry in package.json in order to get a shared prettier configuration in an external module. This PR make depcheck see this dependency.

See https://prettier.io/docs/en/configuration.html#sharing-configurations