### PR TITLE
Try to load eslint.js modules without a module.exports wrapper

### DIFF
--- a/src/utils/linters.js
+++ b/src/utils/linters.js
@@ -23,8 +23,14 @@ export function parse(content) {
     // not valid JavaScript code
   }
 
+  try {
+    return evaluate(content);
+  } catch (error) {
+    // not valid JavaScript code
+  }
+
   // parse fail, return nothing
-  return {};
+  return null;
 }
 
 export function getCustomConfig(kind, filename, content, rootDir) {
@@ -51,11 +57,7 @@ export function getCustomConfig(kind, filename, content, rootDir) {
         const configPath = path.resolve(rootDir, configFile);
 
         const configContent = fs.readFileSync(configPath);
-        try {
-          return JSON.parse(configContent);
-        } catch (e) {
-          return null;
-        }
+        return parse(configContent);
       }
     }
   }

--- a/test/fake_modules/eslint_config_js/config.js
+++ b/test/fake_modules/eslint_config_js/config.js
@@ -1,0 +1,6 @@
+const jsConfig = "not just a simple json object here";
+module.exports = {
+  "extends": [
+    "foo-bar"
+  ]
+};

--- a/test/fake_modules/eslint_config_js/package.json
+++ b/test/fake_modules/eslint_config_js/package.json
@@ -1,0 +1,10 @@
+{
+  "devDependencies": {
+    "eslint-config-foo-bar": "^1.1.1",
+    "eslint": "^1.0.0"
+  },
+  "scripts": {
+    "lint": "eslint --config ./config.js",
+    "unused": "does something else"
+  }
+}

--- a/test/special/eslint.js
+++ b/test/special/eslint.js
@@ -244,6 +244,25 @@ describe('eslint special parser', () => {
       );
       result.should.deepEqual(['eslint-config-foo-bar']);
     });
+
+    it('should parse custom js configs from scripts', () => {
+      const rootDir = path.resolve(
+        __dirname,
+        '../fake_modules/eslint_config_js',
+      );
+      const packagePath = path.resolve(rootDir, 'package.json');
+      const packageContent = fs.readFileSync(packagePath, 'utf-8');
+      const dependencies = Object.keys(
+        JSON.parse(packageContent).devDependencies,
+      );
+      const result = eslintSpecialParser(
+        packageContent,
+        packagePath,
+        dependencies,
+        rootDir,
+      );
+      result.should.deepEqual(['eslint-config-foo-bar']);
+    });
   });
 
   describe('with JSON format', () =>

--- a/test/special/eslint.js
+++ b/test/special/eslint.js
@@ -237,7 +237,11 @@ describe('eslint special parser', () => {
         dependencies,
         rootDir,
       );
-      result.should.deepEqual(['eslint-config-foo-bar']);
+      result.should.deepEqual([
+        'eslint-config-foo-bar',
+        'eslint-plugin-not-included',
+        'eslint-config-preset',
+      ]);
     });
   });
 

--- a/test/special/tslint.js
+++ b/test/special/tslint.js
@@ -116,7 +116,7 @@ describe('tslint special parser', () => {
   });
 
   it('should handle parse error', () =>
-    testTslint(['tslint'], '{ this is an invalid JSON string'));
+    testTslint([], '{ this is an invalid JSON string'));
 
   it('should handle non-standard JSON content', () =>
     testTslint(


### PR DESCRIPTION
 * If the module already uses regular CommonJS syntax, we won't be able to parse it with another wrapper
 * Also fix the custom config case too
 * Also fix the result for parse to return null, to match what evaluate will return if we parse successfully, but nothing is found. This avoids breaking the tslint invalid custom parser case, but breaks the test for an invalid default config. I think this second test is the one that needed to change