### PR TITLE
Document and provide types for the API's package option

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ const options = {
     depcheck.special.eslint,
     depcheck.special.webpack
   ],
+  package: { // may specify dependencies instead of parsing package.json
+    dependencies: {
+      lodash: '^4.17.15'
+    },
+    devDependencies: {
+      eslint: '^6.6.0'
+    },
+    peerDependencies: {},
+    optionalDependencies: {}
+  }
 };
 
 depcheck('/path/to/your/project', options, (unused) => {

--- a/index.d.tmpl
+++ b/index.d.tmpl
@@ -15,11 +15,21 @@ declare namespace depcheck {
 
   type Detector = (node: Node) => ReadonlyArray<string> | string;
 
+  interface PackageDependencies {
+    [dependencyName: string]: string;
+  }
+
   interface Options {
     ignoreBinPackage?: boolean;
     skipMissing?: boolean;
     ignoreDirs?: ReadonlyArray<string>;
     ignoreMatches?: ReadonlyArray<string>;
+    package?: {
+      dependencies?: PackageDependencies;
+      devDependencies?: PackageDependencies;
+      peerDependencies?: PackageDependencies;
+      optionalDependencies?: PackageDependencies;
+    };
     parsers?: {
       [match: string]: Parser;
     };


### PR DESCRIPTION
The `package` property allows specifying dependencies without parsing a `package.json`. I'm finding this useful in my code and thought it'd be nice to document it and make it easier to discover.