### PR TITLE
Adjust babel special to eslint implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6446,11 +6446,6 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-    },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "minimatch": "^3.0.2",
     "node-sass-tilde-importer": "^1.0.2",
     "please-upgrade-node": "^3.2.0",
-    "require-from-string": "^2.0.2",
     "require-package-name": "^2.0.1",
     "resolve": "^1.12.0",
     "vue-template-compiler": "^2.6.10",

--- a/src/special/babel.js
+++ b/src/special/babel.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import lodash from 'lodash';
-import requireFromString from 'require-from-string';
+import { loadConfig } from '../utils/linters';
 
 function parse(content) {
   try {
@@ -81,20 +81,16 @@ function checkOptions(deps, options = {}) {
   return optDeps.concat(envDeps);
 }
 
-export default function parseBabel(content, filePath, deps) {
-  const filename = path.basename(filePath);
+const regex = /^(\.babelrc|babelrc\.js|babel\.config\.js)?$/;
 
-  if (filename === '.babelrc') {
-    const options = parse(content);
-    return checkOptions(deps, options);
+export default function parseBabel(content, filePath, deps, rootDir) {
+  const config = loadConfig('babel', regex, filePath, content, rootDir);
+
+  if (config) {
+    return checkOptions(deps, config);
   }
 
-  if (filename === 'babel.config.js') {
-    const options = requireFromString(content);
-    return checkOptions(deps, options);
-  }
-
-  if (filename === 'package.json') {
+  if (path.basename(filePath) === 'package.json') {
     const metadata = parse(content);
     return checkOptions(deps, metadata.babel);
   }


### PR DESCRIPTION
In fact the babel and eslint special do pretty similar things. This PR unifies the implementation so that the babel special uses the parsing semantics of the linting special(s).