### PR TITLE
Remove remaining dev option

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -84,9 +84,8 @@ function print(result, log, json, rootDir) {
 export default function cli(args, log, error, exit) {
   const opt = yargs(args)
     .usage('Usage: $0 [DIRECTORY]')
-    .boolean(['dev', 'ignore-bin-package', 'skip-missing'])
+    .boolean(['ignore-bin-package', 'skip-missing'])
     .default({
-      dev: true,
       'ignore-bin-package': false,
       'skip-missing': false,
     })


### PR DESCRIPTION
Looks like this was deprecated in https://github.com/depcheck/depcheck/pull/120 and removed in https://github.com/depcheck/depcheck/pull/121.