### PR TITLE
Add eslint-plugin-mocha and lint test directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,10 @@
 # Ignore the following file because it is expected to be syntax error
 test/fake_modules/bad_js/index.js
+# Ignore the following because .eslintrc is a problem
+test/fake_modules/eslint_config/
+test/fake_modules/node_modules/eslint-config-foo-bar/
+# Ignore the following because they're not expected to be linted
+test/fake_modules/eslint_config_js/
+test/fake_modules/import_function/
+test/fake_modules/import_function_missing/
+test/fake_modules/import_function_webpack/

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -7,3 +7,6 @@ rules:
   import/no-dynamic-require: off
 plugins:
   - prettier
+  - mocha
+env:
+  mocha: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -3096,6 +3096,15 @@
         }
       }
     },
+    "eslint-plugin-mocha": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-6.2.2.tgz",
+      "integrity": "sha512-oNhPzfkT6Q6CJ0HMVJ2KLxEWG97VWGTmuHOoRcDLE0U88ugUyFNV9wrT2XIt5cGtqc5W9k38m4xTN34L09KhBA==",
+      "dev": true,
+      "requires": {
+        "ramda": "^0.26.1"
+      }
+    },
     "eslint-plugin-prettier": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
@@ -6890,6 +6899,12 @@
       "requires": {
         "fast-safe-stringify": "^1.0.8"
       }
+    },
+    "ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+      "dev": true
     },
     "react-is": {
       "version": "16.12.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prepublishOnly": "npm run compile && npm run component",
     "prettier": "prettier \"**/*.@(js|json|md|yml)\"",
     "prettier-check": "npm run prettier -- --check",
-    "lint": "eslint ./src ./build",
+    "lint": "eslint ./src ./build ./test",
     "test": "mocha ./test ./test/special --timeout 10000",
     "test-dependent": "dependent-build",
     "test-coverage": "cross-env NODE_ENV=test nyc mocha ./test ./test/special --timeout 20000 && nyc report --reporter=text-lcov > ./coverage/coverage.lcov"

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-jsx-a11y": "^6.1.1",
+    "eslint-plugin-mocha": "^6.2.2",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.17.0",
     "fs-extra": "^8.1.0",

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,5 +1,3 @@
-/* global describe, it, before, after */
-
 import 'should';
 import path from 'path';
 import cli from '../src/cli';

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,3 @@
-/* global describe, it, before, after */
-
 import 'should';
 import fs from 'fs';
 import path from 'path';

--- a/test/special/babel.js
+++ b/test/special/babel.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 import 'should';
 import parse from '../../src/special/babel';
 

--- a/test/special/bin.js
+++ b/test/special/bin.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 import 'should';
 import parse from '../../src/special/bin';
 

--- a/test/special/commitizen.js
+++ b/test/special/commitizen.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 import 'should';
 import commitizenSpecialParser from '../../src/special/commitizen';
 

--- a/test/special/eslint.js
+++ b/test/special/eslint.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 import 'should';
 import yaml from 'js-yaml';
 import * as path from 'path';

--- a/test/special/feross-standard.js
+++ b/test/special/feross-standard.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 import 'should';
 import standardSpecialParser from '../../src/special/feross-standard';
 

--- a/test/special/gatsby.js
+++ b/test/special/gatsby.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 import 'should';
 import gatsbySpecialParser from '../../src/special/gatsby';
 

--- a/test/special/gulp-load-plugins.js
+++ b/test/special/gulp-load-plugins.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 import 'should';
 import parse from '../../src/special/gulp-load-plugins';
 

--- a/test/special/husky.js
+++ b/test/special/husky.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 import 'should';
 import parse from '../../src/special/husky';
 

--- a/test/special/jest.js
+++ b/test/special/jest.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 import 'should';
 import path from 'path';
 import fse from 'fs-extra';

--- a/test/special/karma.js
+++ b/test/special/karma.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 import path from 'path';
 import proxyquire from 'proxyquire';
 import 'should';

--- a/test/special/lint-staged.js
+++ b/test/special/lint-staged.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 import 'should';
 import parse from '../../src/special/lint-staged';
 

--- a/test/special/mocha.js
+++ b/test/special/mocha.js
@@ -1,5 +1,3 @@
-/* global describe, it, beforeEach */
-
 import 'should';
 import fs from 'fs';
 import path from 'path';

--- a/test/special/prettier.js
+++ b/test/special/prettier.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 import 'should';
 import fs from 'fs';
 import path from 'path';

--- a/test/special/tslint.js
+++ b/test/special/tslint.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 import 'should';
 import yaml from 'js-yaml';
 import * as fs from 'fs';

--- a/test/special/ttypescript.js
+++ b/test/special/ttypescript.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 import 'should';
 import path from 'path';
 import fse from 'fs-extra';

--- a/test/special/webpack.js
+++ b/test/special/webpack.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 import 'should';
 import path from 'path';
 import fs from 'fs';


### PR DESCRIPTION
I noticed some `globals` in the test files for `describe` and `it`. I'm proposing to add `eslint-plugin-mocha` as a cleaner alternative. We would later be able to use `plugin:mocha/recommended` to implement good practices in test files.

Also took the opportunity to enforce `lint` in the `test` directory. Added some extra folders to `.eslintignore`for that reason.

Note: CI is not expected to pass yet because of some `prettier` errors. They should be fixed in https://github.com/depcheck/depcheck/pull/490
