### PR TITLE
Update travis commands and reference

### DIFF
--- a/src/utils/get-scripts.js
+++ b/src/utils/get-scripts.js
@@ -32,7 +32,7 @@ const travisCommands = [
   'after_success',
   'after_failure',
   'before_deploy',
-  'deploy',
+  // 'deploy', // currently ignored
   'after_deploy',
   'after_script',
 ];

--- a/src/utils/get-scripts.js
+++ b/src/utils/get-scripts.js
@@ -23,13 +23,16 @@ function getCacheOrFile(key, fn) {
 }
 
 const travisCommands = [
-  // Reference: http://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle
+  // Reference: https://docs.travis-ci.com/user/job-lifecycle
   'before_install',
   'install',
   'before_script',
   'script',
-  'after_success or after_failure',
+  'before_cache',
+  'after_success',
+  'after_failure',
   'before_deploy',
+  'deploy',
   'after_deploy',
   'after_script',
 ];


### PR DESCRIPTION
- the link to Travis docs was outdated
- the list was incomplete
- `after_success or after_failure` was wrongly set as one command