### PR TITLE
Support for .*ignore files

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,11 @@ All of the arguments are optional:
 
 `--ignores`: A comma separated array containing package names to ignore. It can be glob expressions. Example, `--ignores="eslint,babel-*"`.
 
-`--ignore-dirs`: A comma separated array containing directory names to ignore. Example, `--ignore-dirs=dist,coverage`.
+`--ignore-dirs`: DEPRECATED, use ignore-patterns instead. A comma separated array containing directory names to ignore. Example, `--ignore-dirs=dist,coverage`.
+
+`--ignore-path`: Path to a file with patterns describing files to ignore. Files must match the .gitignore [spec](http://git-scm.com/docs/gitignore). Example, `--ignore-path=.eslintignore`.
+
+`--ignore-patterns`: Comma separated patterns describing files to ignore. Patterns must match the .gitignore [spec](http://git-scm.com/docs/gitignore). Example, `--ignore-patterns=build/Release,dist,coverage,*.log`.
 
 `--help`: Show the help message.
 
@@ -112,8 +116,8 @@ import depcheck from 'depcheck';
 const options = {
   ignoreBinPackage: false, // ignore the packages with bin entry
   skipMissing: false, // skip calculation of missing dependencies
-  ignoreDirs: [
-    // folder with these names will be ignored
+  ignorePatterns: [
+    // files matching these patterns will be ignored
     'sandbox',
     'dist',
     'bower_components',

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,20 @@
             "path-is-absolute": "^1.0.0",
             "readdirp": "^2.2.1",
             "upath": "^1.1.1"
+          },
+          "dependencies": {
+            "readdirp": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+              "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "graceful-fs": "^4.1.11",
+                "micromatch": "^3.1.10",
+                "readable-stream": "^2.0.2"
+              }
+            }
           }
         },
         "commander": {
@@ -2598,6 +2612,20 @@
         "path-is-absolute": "^1.0.0",
         "readdirp": "^2.2.1",
         "upath": "^1.1.1"
+      },
+      "dependencies": {
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
+        }
       }
     },
     "class-utils": {
@@ -3250,6 +3278,12 @@
           "requires": {
             "type-fest": "^0.8.1"
           }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
         },
         "path-key": {
           "version": "2.0.1",
@@ -5079,10 +5113,9 @@
       }
     },
     "ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-      "dev": true
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+      "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
     },
     "ignore-walk": {
       "version": "3.0.3",
@@ -7358,8 +7391,7 @@
     "picomatch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
-      "dev": true
+      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
     },
     "pify": {
       "version": "4.0.1",
@@ -7697,15 +7729,11 @@
       }
     },
     "readdirp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-      "dev": true,
-      "optional": true,
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
+        "picomatch": "^2.2.1"
       }
     },
     "redent": {
@@ -9207,11 +9235,6 @@
         "de-indent": "^1.0.2",
         "he": "^1.1.0"
       }
-    },
-    "walkdir": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
-      "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -57,15 +57,16 @@
     "cosmiconfig": "^6.0.0",
     "debug": "^4.1.1",
     "deps-regex": "^0.1.4",
+    "ignore": "^5.1.4",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.15",
     "minimatch": "^3.0.4",
     "node-sass-tilde-importer": "^1.0.2",
     "please-upgrade-node": "^3.2.0",
+    "readdirp": "^3.4.0",
     "require-package-name": "^2.0.1",
     "resolve": "^1.15.0",
     "vue-template-compiler": "^2.6.11",
-    "walkdir": "^0.4.1",
     "yargs": "^15.1.0"
   },
   "devDependencies": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -109,6 +109,7 @@ export default async function cli(args, log, error, exit) {
     );
     const depcheckResult = await depcheck(rootDir, {
       ignoreBinPackage: opt.ignoreBinPackage,
+      ignorePath: opt.ignorePath,
       ignoreMatches: opt.ignores || [],
       ignoreDirs: opt.ignoreDirs || [],
       parsers: getParsers(opt.parsers),

--- a/src/cli.js
+++ b/src/cli.js
@@ -112,6 +112,7 @@ export default async function cli(args, log, error, exit) {
       ignorePath: opt.ignorePath,
       ignoreMatches: opt.ignores || [],
       ignoreDirs: opt.ignoreDirs || [],
+      ignorePatterns: opt.ignorePatterns || [],
       parsers: getParsers(opt.parsers),
       detectors: getDetectors(opt.detectors),
       specials: getSpecials(opt.specials),

--- a/src/constants.js
+++ b/src/constants.js
@@ -21,13 +21,29 @@ export const availableSpecials = constructComponent(component, 'special');
 export const defaultOptions = {
   ignoreBinPackage: false,
   ignoreMatches: [],
-  ignoreDirs: [
+  ignorePatterns: [
     '.git',
     '.svn',
     '.hg',
     '.idea',
     'node_modules',
     'bower_components',
+    // Images
+    '*.png',
+    '*.gif',
+    '*.jpg',
+    '*.jpeg',
+    '*.svg',
+    // Fonts
+    '*.woff',
+    '*.woff2',
+    '*.eot',
+    '*.ttf',
+    // Archives
+    '*.zip',
+    '*.gz',
+    // Videos
+    '*.mp4',
   ],
   skipMissing: false,
   parsers: {

--- a/src/utils/configuration-reader.js
+++ b/src/utils/configuration-reader.js
@@ -34,7 +34,18 @@ export function getCliArgs(args, version) {
     .describe('skip-missing', 'Skip calculation of missing dependencies')
     .describe('json', 'Output results to JSON')
     .describe('ignores', 'Comma separated package list to ignore')
-    .describe('ignore-dirs', 'Comma separated folder names to ignore')
+    .describe(
+      'ignore-dirs',
+      'Comma separated folder names to ignore (deprecated)',
+    )
+    .describe(
+      'ignore-path',
+      'Path to a file with patterns describing files to ignore.',
+    )
+    .describe(
+      'ignore-patterns',
+      'Comma separated patterns describing files to ignore.',
+    )
     .describe('parsers', 'Comma separated glob:parser pair list')
     .describe('detectors', 'Comma separated detector list')
     .describe('specials', 'Comma separated special parser list')

--- a/src/utils/configuration-reader.js
+++ b/src/utils/configuration-reader.js
@@ -51,7 +51,10 @@ export function getCliArgs(args, version) {
     .describe('specials', 'Comma separated special parser list')
     .version('version', 'Show version number', version)
     .help('help', 'Show this help message')
-    .coerce(['ignores', 'ignore-dirs', 'detectors', 'specials'], parseCsvArray)
+    .coerce(
+      ['ignores', 'ignore-dirs', 'ignore-patterns', 'detectors', 'specials'],
+      parseCsvArray,
+    )
     .coerce('parsers', (parsersStr) => {
       const parsers = parseCsvArray(parsersStr);
       return createParsersObject(parsers);

--- a/test/fake_modules/depcheckignore/.depcheckignore
+++ b/test/fake_modules/depcheckignore/.depcheckignore
@@ -1,0 +1,1 @@
+ignored/*

--- a/test/fake_modules/depcheckignore/ignored/ignored.js
+++ b/test/fake_modules/depcheckignore/ignored/ignored.js
@@ -1,0 +1,1 @@
+require('debug');

--- a/test/fake_modules/depcheckignore/package.json
+++ b/test/fake_modules/depcheckignore/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "lodash": "0.0.1",
+    "debug": "0.0.1"
+  }
+}

--- a/test/fake_modules/depcheckignore/used.js
+++ b/test/fake_modules/depcheckignore/used.js
@@ -1,0 +1,2 @@
+require('lodash');
+require('react');

--- a/test/spec.js
+++ b/test/spec.js
@@ -766,4 +766,38 @@ export default [
     },
     expectedErrorCode: 0,
   },
+  {
+    name: 'support .depcheckignore',
+    module: 'depcheckignore',
+    options: {},
+    expected: {
+      dependencies: [],
+      devDependencies: ['debug'],
+      missing: {
+        react: ['used.js'],
+      },
+      using: {
+        lodash: ['used.js'],
+        react: ['used.js'],
+      },
+    },
+    expectedErrorCode: -1,
+  },
+  {
+    name: 'support ignorePath',
+    module: 'depcheckignore',
+    options: { ignorePath: '.depcheckignore' },
+    expected: {
+      dependencies: [],
+      devDependencies: ['debug'],
+      missing: {
+        react: ['used.js'],
+      },
+      using: {
+        lodash: ['used.js'],
+        react: ['used.js'],
+      },
+    },
+    expectedErrorCode: -1,
+  },
 ];

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,4 @@
 import path from 'path';
-import fs from 'fs';
 import fse from 'fs-extra';
 import { setContent } from '../src/utils/file';
 
@@ -7,9 +6,9 @@ export function resolveShortPath(expected, module) {
   return Object.keys(expected).reduce(
     (obj, key) => ({
       ...obj,
-      [key]: expected[key].map((name) =>
-        fs.realpathSync(path.resolve(__dirname, 'fake_modules', module, name)),
-      ),
+      [key]: expected[key].map((name) => {
+        return path.resolve(__dirname, 'fake_modules', module, name);
+      }),
     }),
     {},
   );


### PR DESCRIPTION
Implement https://github.com/depcheck/depcheck/issues/497

- Introduce `ignore` dependency: https://www.npmjs.com/package/ignore
  - "ignore is a manager, filter and parser which implemented in pure JavaScript according to the .gitignore spec"
  - "ignore is used by eslint, gitbook and many others"
- Keep supporting `ignoreDirs` with a different implementation
  - `ignoreDirs` is now deprecated
  - while mostly retro-compatible, this is technically a breaking change
- Introduce `ignorePatterns`:
  - aims to replace ignoreDirs, use patterns instead of single level directory names
- Introduce `ignorePath`
  - Support any ignore file passed as `ignorePath` (ie: .eslintignore, .prettierignore)
  - If no `ignorePath`, try to use `.depcheckignore` or `.gitignore` in that order
- Switch file walker from `walkdir` to `readdirp`
  - simpler: ability to work recursively
  - ability to filter both files (`fileFilter`) and directories (`directoryFilter`)
  - easier to work with `ignore` package
- Start ignoring based on file extension:
  - images (.png, .gif, .jpg, .svg)
  - fonts (.woff, .woff, .eot, .ttf)
  - archives (.zip, .gz)
  - videos (.mp4)