### PR TITLE
Improve recursive work of eslint configuration check

### DIFF
--- a/test/fake_modules/eslint_config_custom/config.json
+++ b/test/fake_modules/eslint_config_custom/config.json
@@ -1,3 +1,4 @@
 {
-  "extends": "eslint-config-foo-bar"
+  "extends": "eslint-config-foo-bar",
+  "plugins": ["ignored"]
 }

--- a/test/fake_modules/node_modules/eslint-config-foo-bar/package.json
+++ b/test/fake_modules/node_modules/eslint-config-foo-bar/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.1",
   "main": ".eslintrc.js",
   "dependencies": {
-    "eslint-plugin-included": "^1.1.1"
+    "eslint-plugin-included": "^1.1.1",
+    "eslint-plugin-ignored": "^0.1.1"
   }
 }

--- a/test/special/eslint.js
+++ b/test/special/eslint.js
@@ -213,6 +213,7 @@ describe('eslint special parser', () => {
         rootDir,
       );
       result.should.deepEqual([
+        'eslint-plugin-ignored',
         'eslint-config-foo-bar',
         'eslint-plugin-not-included',
         'eslint-config-preset',


### PR DESCRIPTION
The eslint special parser should not require a dependency which is used in an inherited configuration
if this dependency is already a dependency of this inherited configuration, but it should require
a dependency which is directly used, even if it is already a dependency's dependency.

Issue #500