### PR TITLE
Refactor: read content only when needed

### DIFF
--- a/src/parser/coffee.js
+++ b/src/parser/coffee.js
@@ -1,7 +1,9 @@
 import DepsRegex from 'deps-regex';
+import { getContent } from '../utils/file';
 
 const re = new DepsRegex({ matchES6: false });
 
-export default function parseCoffeeScript(content) {
+export default async function parseCoffeeScript(filename) {
+  const content = await getContent(filename);
   return re.getDependencies(content);
 }

--- a/src/parser/es6.js
+++ b/src/parser/es6.js
@@ -1,6 +1,8 @@
 import { parse } from '@babel/parser';
+import { getContent } from '../utils/file';
 
-export default function parseES6(content) {
+export default async function parseES6(filename) {
+  const content = await getContent(filename);
   return parse(content, {
     sourceType: 'module',
   });

--- a/src/parser/es7.js
+++ b/src/parser/es7.js
@@ -1,6 +1,7 @@
 import { parse } from '@babel/parser';
+import { getContent } from '../utils/file';
 
-export default function parseES7(content) {
+export function parseES7Content(content) {
   return parse(content, {
     sourceType: 'module',
 
@@ -34,4 +35,9 @@ export default function parseES7(content) {
       'throwExpressions',
     ],
   });
+}
+
+export default async function parseES7(filename) {
+  const content = await getContent(filename);
+  return parseES7Content(content);
 }

--- a/src/parser/jsx.js
+++ b/src/parser/jsx.js
@@ -1,6 +1,8 @@
 import { parse } from '@babel/parser';
+import { getContent } from '../utils/file';
 
-export default function parseJSX(content) {
+export default async function parseJSX(filename) {
+  const content = await getContent(filename);
   return parse(content, {
     sourceType: 'module',
 

--- a/src/parser/sass.js
+++ b/src/parser/sass.js
@@ -6,10 +6,10 @@ import { tryRequire } from '../utils';
 
 const sass = tryRequire('node-sass');
 
-export default function parseSASS(content, filePath, deps, rootDir) {
+export default async function parseSASS(filename, deps, rootDir) {
   const { stats } = sass.renderSync({
-    file: filePath,
-    includePaths: [path.dirname(filePath)],
+    file: filename,
+    includePaths: [path.dirname(filename)],
     importer: tildeImporter,
   });
 

--- a/src/parser/typescript.js
+++ b/src/parser/typescript.js
@@ -1,6 +1,8 @@
 import { parse } from '@babel/parser';
+import { getContent } from '../utils/file';
 
-export default function parseTypescript(content) {
+export default async function parseTypescript(filename) {
+  const content = await getContent(filename);
   // Enable all known compatible @babel/parser plugins at the time of writing.
   // Because we only parse them, not evaluate any code, it is safe to do so.
   // note that babel/parser 7+ does not support *, due to plugin incompatibilities

--- a/src/parser/vue.js
+++ b/src/parser/vue.js
@@ -1,7 +1,9 @@
 import { parse } from '@babel/parser';
 import { parseComponent } from 'vue-template-compiler';
+import { getContent } from '../utils/file';
 
-export default function parseVue(content) {
+export default async function parseVue(filename) {
+  const content = await getContent(filename);
   const parsed = parseComponent(content);
   if (!parsed.script) {
     return [];

--- a/src/special/babel.js
+++ b/src/special/babel.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import lodash from 'lodash';
 import { loadConfig } from '../utils/cli-tools';
+import { getContent } from '../utils/file';
 
 function parse(content) {
   try {
@@ -83,14 +84,15 @@ function checkOptions(deps, options = {}) {
 
 const regex = /^(\.babelrc|babelrc\.js|babel\.config\.js)?$/;
 
-export default function parseBabel(content, filePath, deps, rootDir) {
-  const config = loadConfig('babel', regex, filePath, content, rootDir);
+export default async function parseBabel(filename, deps, rootDir) {
+  const config = await loadConfig('babel', regex, filename, rootDir);
 
   if (config) {
     return checkOptions(deps, config);
   }
 
-  if (path.basename(filePath) === 'package.json') {
+  if (path.basename(filename) === 'package.json') {
+    const content = await getContent(filename);
     const metadata = parse(content);
     return checkOptions(deps, metadata.babel);
   }

--- a/src/special/bin.js
+++ b/src/special/bin.js
@@ -49,7 +49,7 @@ function isBinaryInUse(dep, scripts, dir) {
   );
 }
 
-export default function parseBinary(content, filepath, deps, dir) {
-  const scripts = getScripts(filepath, content);
+export default async function parseBinary(filename, deps, dir) {
+  const scripts = await getScripts(filename);
   return deps.filter((dep) => isBinaryInUse(dep, scripts, dir));
 }

--- a/src/special/commitizen.js
+++ b/src/special/commitizen.js
@@ -1,11 +1,14 @@
 import path from 'path';
 import requirePackageName from 'require-package-name';
+import { getContent } from '../utils/file';
 
-export default function parseCommitizen(content, filePath, deps, rootDir) {
+export default async function parseCommitizen(filename, deps, rootDir) {
   const packageJsonPath = path.resolve(rootDir, 'package.json');
-  const resolvedFilePath = path.resolve(filePath);
+  const resolvedFilePath = path.resolve(filename);
 
   if (resolvedFilePath === packageJsonPath) {
+    const content = await getContent(filename);
+
     const metadata = JSON.parse(content);
 
     if (

--- a/src/special/eslint.js
+++ b/src/special/eslint.js
@@ -3,6 +3,7 @@ import lodash from 'lodash';
 import requirePackageName from 'require-package-name';
 import { loadModuleData, wrapToArray } from '../utils';
 import { loadConfig } from '../utils/cli-tools';
+import { getContent } from '../utils/file';
 
 function resolveConfigModule(preset, rootDir) {
   const presetParts = preset.split('/');
@@ -139,14 +140,8 @@ function checkConfig(config, rootDir, includedDeps = []) {
 
 const configNameRegex = /^\.eslintrc(\.(json|js|yml|yaml))?$/;
 
-export default function parseESLint(content, filename, _, rootDir) {
-  const config = loadConfig(
-    'eslint',
-    configNameRegex,
-    filename,
-    content,
-    rootDir,
-  );
+export default async function parseESLint(filename, deps, rootDir) {
+  const config = await loadConfig('eslint', configNameRegex, filename, rootDir);
 
   if (config) {
     return checkConfig(config, rootDir);
@@ -156,6 +151,7 @@ export default function parseESLint(content, filename, _, rootDir) {
   const resolvedFilePath = path.resolve(rootDir, filename);
 
   if (resolvedFilePath === packageJsonPath) {
+    const content = await getContent(filename);
     const parsed = JSON.parse(content);
     if (parsed.eslintConfig) {
       return checkConfig(parsed.eslintConfig, rootDir);

--- a/src/special/feross-standard.js
+++ b/src/special/feross-standard.js
@@ -1,9 +1,11 @@
 import path from 'path';
+import { getContent } from '../utils/file';
 
-export default function parseFerossStandard(content, filePath, deps, rootDir) {
+export default async function parseFerossStandard(filename, deps, rootDir) {
   const packageJsonPath = path.resolve(rootDir, 'package.json');
-  const resolvedFilePath = path.resolve(filePath);
+  const resolvedFilePath = path.resolve(filename);
   if (resolvedFilePath === packageJsonPath && deps.indexOf('standard') !== -1) {
+    const content = await getContent(filename);
     const metadata = JSON.parse(content);
     const config = metadata.standard || {};
     const { parser } = config;

--- a/src/special/gatsby.js
+++ b/src/special/gatsby.js
@@ -1,7 +1,8 @@
 import path from 'path';
 import lodash from 'lodash';
-import parseES7 from '../parser/es7';
+import { parseES7Content } from '../parser/es7';
 import getNodes from '../utils/parser';
+import { getContent } from '../utils/file';
 
 function parseConfigModuleExports(node) {
   // node.left must be assigning to module.exports
@@ -33,8 +34,9 @@ function parseConfigModuleExports(node) {
   }
   return null;
 }
-function parseConfig(content) {
-  const ast = parseES7(content);
+
+async function parseConfig(content) {
+  const ast = parseES7Content(content);
   return lodash(getNodes(ast))
     .map((node) => parseConfigModuleExports(node))
     .flatten()
@@ -43,17 +45,14 @@ function parseConfig(content) {
     .first();
 }
 
-function loadConfig(filename, content) {
+export default async function parseGatsbyConfig(filename) {
   const basename = path.basename(filename);
 
   const GatbyConfig = 'gatsby-config.js';
   if (GatbyConfig === basename) {
-    const config = parseConfig(content);
+    const content = await getContent(filename);
+    const config = await parseConfig(content);
     return config.plugins || [];
   }
   return [];
-}
-
-export default function parseGatsbyConfig(content, filename) {
-  return loadConfig(filename, content);
 }

--- a/src/special/gulp-load-plugins.js
+++ b/src/special/gulp-load-plugins.js
@@ -3,9 +3,10 @@ import lodash from 'lodash';
 import minimatch from 'minimatch';
 import traverse from '@babel/traverse';
 
-import esParser from '../parser/es7';
+import { parseES7Content } from '../parser/es7';
 import importDetector from '../detector/importDeclaration';
 import requireDetector from '../detector/requireCallExpression';
+import { getContent } from '../utils/file';
 
 function getPluginLookup(deps) {
   const patterns = ['gulp-*', 'gulp.*', '@*/gulp{-,.}*'];
@@ -164,8 +165,8 @@ function check(content, deps, path) {
   return [];
 }
 
-export default function parseGulpPlugins(content, filePath, deps, rootDir) {
-  const resolvedPath = resolve(filePath);
+export default async function parseGulpPlugins(filename, deps, rootDir) {
+  const resolvedPath = resolve(filename);
   if (
     resolvedPath !== resolve(rootDir, 'gulpfile.js') &&
     resolvedPath !== resolve(rootDir, 'gulpfile.babel.js')
@@ -174,7 +175,8 @@ export default function parseGulpPlugins(content, filePath, deps, rootDir) {
   }
 
   const pluginLookup = getPluginLookup(deps);
-  const ast = esParser(content);
+  const content = await getContent(filename);
+  const ast = await parseES7Content(content);
   const results = [];
   traverse(ast, {
     enter(path) {

--- a/src/special/husky.js
+++ b/src/special/husky.js
@@ -1,9 +1,11 @@
 import * as path from 'path';
+import { getContent } from '../utils/file';
 
-export default function parseHusky(content, filename) {
+export default async function parseHusky(filename) {
   const basename = path.basename(filename);
 
   if (basename === 'package.json') {
+    const content = await getContent(filename);
     const pkg = JSON.parse(content);
     return pkg.husky ? ['husky'] : [];
   }

--- a/src/special/istanbul.js
+++ b/src/special/istanbul.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import { parse } from '../utils/cli-tools';
+import { getContent } from '../utils/file';
 
 const configNameRegex = /^(\.nycrc(\.(json|yml|yaml))?|nyc.config.js)$/;
 
@@ -22,13 +23,15 @@ function getExtendsDependencies(extendConfig, deps) {
   return dependencies;
 }
 
-export default function parseIstanbul(content, filepath, deps) {
-  const basename = path.basename(filepath);
+export default async function parseIstanbul(filename, deps) {
+  const basename = path.basename(filename);
   let config;
 
   if (configNameRegex.test(basename)) {
+    const content = await getContent(filename);
     config = parse(content);
   } else if (basename === 'package.json') {
+    const content = await getContent(filename);
     config = JSON.parse(content).nyc;
   }
 

--- a/src/special/jest.js
+++ b/src/special/jest.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import lodash from 'lodash';
+import { getContent } from '../utils/file';
 
 const _ = lodash;
 
@@ -92,12 +93,12 @@ function checkOptions(deps, options = {}) {
   return filter(deps, pickedOptions);
 }
 
-export default function parseJest(content, filePath, deps, rootDir) {
-  const filename = path.basename(filePath);
-  if (jestConfigRegex.test(filename)) {
+export default async function parseJest(filename, deps, rootDir) {
+  const basename = path.basename(filename);
+  if (jestConfigRegex.test(basename)) {
     try {
       // eslint-disable-next-line global-require
-      const options = require(filePath) || {};
+      const options = require(filename) || {};
       return checkOptions(deps, options);
     } catch (error) {
       return [];
@@ -108,6 +109,7 @@ export default function parseJest(content, filePath, deps, rootDir) {
   const resolvedFilePath = path.resolve(rootDir, filename);
 
   if (resolvedFilePath === packageJsonPath) {
+    const content = await getContent(filename);
     const metadata = parse(content);
     return checkOptions(deps, metadata.jest);
   }

--- a/src/special/lint-staged.js
+++ b/src/special/lint-staged.js
@@ -1,9 +1,11 @@
 import * as path from 'path';
+import { getContent } from '../utils/file';
 
-export default function parseLintStaged(content, filename) {
+export default async function parseLintStaged(filename) {
   const basename = path.basename(filename);
 
   if (basename === 'package.json') {
+    const content = await getContent(filename);
     const pkg = JSON.parse(content);
     return pkg['lint-staged'] ? ['lint-staged'] : [];
   }

--- a/src/special/prettier.js
+++ b/src/special/prettier.js
@@ -1,10 +1,9 @@
 import path from 'path';
 import { readJSON } from '../utils';
 
-export default function parsePrettier(content, filepath) {
-  const filename = path.basename(filepath);
-  if (filename === 'package.json') {
-    const config = readJSON(filepath);
+export default function parsePrettier(filename) {
+  if (path.basename(filename) === 'package.json') {
+    const config = readJSON(filename);
     if (config && config.prettier && typeof config.prettier === 'string') {
       return [config.prettier];
     }

--- a/src/special/tslint.js
+++ b/src/special/tslint.js
@@ -39,14 +39,8 @@ const configNameRegex = /^tslint\.(json|yaml|yml)$/;
  * More info on this can be found
  * [here](https://palantir.github.io/tslint/usage/configuration/).
  */
-export default function parseTSLint(content, filename, deps, rootDir) {
-  const config = loadConfig(
-    'tslint',
-    configNameRegex,
-    filename,
-    content,
-    rootDir,
-  );
+export default async function parseTSLint(filename, deps, rootDir) {
+  const config = await loadConfig('tslint', configNameRegex, filename, rootDir);
 
   if (config) {
     return ['tslint', ...checkConfig(config, rootDir)];

--- a/src/special/ttypescript.js
+++ b/src/special/ttypescript.js
@@ -5,10 +5,10 @@ import { readJSON } from '../utils';
 // Search in all files looking like a TypeScript configuration file.
 const tsconfigPattern = /tsconfig(?:\.[^.]+)*\.json/;
 
-export default function parseTTypeScript(_content, filepath, deps) {
-  const filename = path.basename(filepath);
-  if (tsconfigPattern.test(filename)) {
-    const content = readJSON(filepath) || {};
+export default function parseTTypeScript(filename, deps) {
+  const basename = path.basename(filename);
+  if (tsconfigPattern.test(basename)) {
+    const content = readJSON(filename) || {};
     if (content.compilerOptions && content.compilerOptions.plugins) {
       return lodash(content.compilerOptions.plugins)
         .filter((plugin) => plugin.transform)

--- a/src/special/webpack.js
+++ b/src/special/webpack.js
@@ -155,25 +155,25 @@ function loadNextWebpackConfig(filepath) {
   return null;
 }
 
-export default function parseWebpack(_content, filepath, deps) {
-  const filename = path.basename(filepath);
+export default function parseWebpack(filename, deps) {
+  const basename = path.basename(filename);
 
-  if (webpackConfigRegex.test(filename)) {
-    const webpackConfig = tryRequire(filepath);
+  if (webpackConfigRegex.test(basename)) {
+    const webpackConfig = tryRequire(filename);
     if (webpackConfig) {
       return parseWebpackConfig(webpackConfig, deps);
     }
   }
 
-  if (filename === 'styleguide.config.js') {
-    const styleguideConfig = tryRequire(filepath);
+  if (basename === 'styleguide.config.js') {
+    const styleguideConfig = tryRequire(filename);
     if (styleguideConfig && styleguideConfig.webpackConfig) {
       return parseWebpackConfig(styleguideConfig.webpackConfig, deps);
     }
   }
 
-  if (filename === 'next.config.js') {
-    const webpackConfig = loadNextWebpackConfig(filepath);
+  if (basename === 'next.config.js') {
+    const webpackConfig = loadNextWebpackConfig(filename);
     if (webpackConfig) {
       return parseWebpackConfig(webpackConfig, deps);
     }

--- a/src/utils/cli-tools.js
+++ b/src/utils/cli-tools.js
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { evaluate } from '.';
 import getScripts from './get-scripts';
+import { getContent } from './file';
 
 const optionKeysForConfig = {
   babel: ['--config-file'],
@@ -39,8 +40,8 @@ export function parse(content) {
   return null;
 }
 
-export function getCustomConfig(binName, filename, content, rootDir) {
-  const scripts = getScripts(filename, content);
+export async function getCustomConfig(binName, filename, rootDir) {
+  const scripts = await getScripts(filename);
 
   if (scripts.length === 0) {
     return null;
@@ -71,15 +72,16 @@ export function getCustomConfig(binName, filename, content, rootDir) {
   return null;
 }
 
-export function loadConfig(binName, filenameRegex, filename, content, rootDir) {
+export async function loadConfig(binName, filenameRegex, filename, rootDir) {
   const basename = path.basename(filename);
 
   if (filenameRegex.test(basename)) {
+    const content = await getContent(filename);
     const config = parse(content);
     return config;
   }
 
-  const custom = getCustomConfig(binName, filename, content, rootDir);
+  const custom = await getCustomConfig(binName, filename, rootDir);
 
   if (custom) {
     return custom;

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -13,3 +13,7 @@ export function getContent(filename) {
   }
   return promises[filename];
 }
+
+export function setContent(filename, content) {
+  promises[filename] = Promise.resolve(content);
+}

--- a/test/fake_parsers/exception.js
+++ b/test/fake_parsers/exception.js
@@ -1,3 +1,6 @@
-export default (content) => {
+import { getContent } from '../../src/utils/file';
+
+export default async (filename) => {
+  const content = await getContent(filename);
   throw new SyntaxError(content); // throws syntax error any way
 };

--- a/test/fake_parsers/importList.js
+++ b/test/fake_parsers/importList.js
@@ -1,3 +1,5 @@
+import { getContent } from '../../src/utils/file';
+
 function toRequire(dep) {
   return {
     type: 'ImportDeclaration',
@@ -8,13 +10,15 @@ function toRequire(dep) {
   };
 }
 
-export function lite(content) {
+export async function lite(filename) {
+  const content = await getContent(filename);
   return content
     .replace(/\r\n/g, '\n')
     .split('\n')
     .filter((line) => line);
 }
 
-export function full(content) {
-  return lite(content).map(toRequire);
+export async function full(filename) {
+  const result = await lite(filename);
+  return result.map(toRequire);
 }

--- a/test/fake_parsers/multiple.js
+++ b/test/fake_parsers/multiple.js
@@ -1,3 +1,5 @@
+import { getContent } from '../../src/utils/file';
+
 function parser(prefix, content) {
   return content
     .replace(/\r\n/g, '\n')
@@ -12,6 +14,12 @@ function parser(prefix, content) {
     }));
 }
 
-export const multipleParserA = (content) => parser('parser_a,', content);
+export const multipleParserA = async (filename) => {
+  const content = await getContent(filename);
+  return parser('parser_a,', content);
+};
 
-export const multipleParserB = (content) => parser('parser_b,', content);
+export const multipleParserB = async (filename) => {
+  const content = await getContent(filename);
+  return parser('parser_b,', content);
+};

--- a/test/special/babel.js
+++ b/test/special/babel.js
@@ -1,5 +1,8 @@
 import 'should';
-import parse from '../../src/special/babel';
+import parser from '../../src/special/babel';
+import { getTestParserWithContentPromise } from '../utils';
+
+const testParser = getTestParserWithContentPromise(parser);
 
 const testCases = [
   {
@@ -111,33 +114,37 @@ const testCases = [
   },
 ];
 
-function testBabel(filename, deps, content) {
-  const result = parse(content ? JSON.stringify(content) : '', filename, deps);
+async function testBabel(filename, deps, content) {
+  const result = await testParser(
+    content ? JSON.stringify(content) : '',
+    filename,
+    deps,
+  );
   result.should.deepEqual(deps);
 }
 
 describe('babel special parser', () => {
-  it('should ignore when filename is not supported', () => {
-    const result = parse('content', 'not-supported.txt', ['deps']);
+  it('should ignore when filename is not supported', async () => {
+    const result = await parser('not-supported.txt', ['deps']);
     result.should.deepEqual([]);
   });
 
-  it('should recognize dependencies not a babel plugin', () => {
+  it('should recognize dependencies not a babel plugin', async () => {
     const content = JSON.stringify({
       presets: ['es2015'],
     });
 
-    const result = parse(content, '/path/to/.babelrc', [
+    const result = await testParser(content, '/path/to/.babelrc', [
       'babel-preset-es2015',
       'dep',
     ]);
     result.should.deepEqual(['babel-preset-es2015']);
   });
 
-  it('should detect babel.config.js', () => {
+  it('should detect babel.config.js', async () => {
     const content = "module.exports = { presets: ['es2015' ] }";
 
-    const result = parse(content, '/path/to/babel.config.js', [
+    const result = await testParser(content, '/path/to/babel.config.js', [
       'babel-preset-es2015',
       'dep',
     ]);

--- a/test/special/commitizen.js
+++ b/test/special/commitizen.js
@@ -1,30 +1,27 @@
 import 'should';
-import commitizenSpecialParser from '../../src/special/commitizen';
+import parser from '../../src/special/commitizen';
+import { getTestParserWithContentPromise } from '../utils';
+
+const testParser = getTestParserWithContentPromise(parser);
 
 describe('commitizen special parser', () => {
-  it('should ignore when it is not `package.json`', () => {
-    const result = commitizenSpecialParser('content', '/a/file', [], '/a');
+  it('should ignore when it is not `package.json`', async () => {
+    const result = await parser('/a/file', [], '/a');
     result.should.deepEqual([]);
   });
 
-  it('should ignore when path is missing', () => {
+  it('should ignore when path is missing', async () => {
     const metadata = {
       config: {
         commitizen: {},
       },
     };
-
     const content = JSON.stringify(metadata);
-    const result = commitizenSpecialParser(
-      content,
-      '/a/package.json',
-      [],
-      '/a',
-    );
+    const result = await testParser(content, '/a/package.json', [], '/a');
     result.should.deepEqual([]);
   });
 
-  it('should recognize the module used by commitizen (long style)', () => {
+  it('should recognize the module used by commitizen (long style)', async () => {
     const metadata = {
       config: {
         commitizen: {
@@ -32,18 +29,12 @@ describe('commitizen special parser', () => {
         },
       },
     };
-
     const content = JSON.stringify(metadata);
-    const result = commitizenSpecialParser(
-      content,
-      '/a/package.json',
-      [],
-      '/a',
-    );
+    const result = await testParser(content, '/a/package.json', [], '/a');
     result.should.deepEqual(['cz-test']);
   });
 
-  it('should recognize the module used by commitizen (short style)', () => {
+  it('should recognize the module used by commitizen (short style)', async () => {
     const metadata = {
       config: {
         commitizen: {
@@ -51,14 +42,8 @@ describe('commitizen special parser', () => {
         },
       },
     };
-
     const content = JSON.stringify(metadata);
-    const result = commitizenSpecialParser(
-      content,
-      '/a/package.json',
-      [],
-      '/a',
-    );
+    const result = await testParser(content, '/a/package.json', [], '/a');
     result.should.deepEqual(['cz-test']);
   });
 });

--- a/test/special/feross-standard.js
+++ b/test/special/feross-standard.js
@@ -1,18 +1,16 @@
 import 'should';
-import standardSpecialParser from '../../src/special/feross-standard';
+import parser from '../../src/special/feross-standard';
+import { getTestParserWithContentPromise } from '../utils';
+
+const testParser = getTestParserWithContentPromise(parser);
 
 describe('feross standard special parser', () => {
-  it('should ignore when it is not `package.json`', () => {
-    const result = standardSpecialParser(
-      'content',
-      '/a/file',
-      ['standard'],
-      '/a',
-    );
+  it('should ignore when it is not `package.json`', async () => {
+    const result = await parser('/a/file', ['standard'], '/a');
     result.should.deepEqual([]);
   });
 
-  it('should recognize the parser used by feross standard', () => {
+  it('should recognize the parser used by feross standard', async () => {
     const metadata = {
       standard: {
         parser: 'babel-eslint',
@@ -20,7 +18,7 @@ describe('feross standard special parser', () => {
     };
 
     const content = JSON.stringify(metadata);
-    const result = standardSpecialParser(
+    const result = await testParser(
       content,
       '/a/package.json',
       ['standard'],

--- a/test/special/gatsby.js
+++ b/test/special/gatsby.js
@@ -1,18 +1,21 @@
 import 'should';
-import gatsbySpecialParser from '../../src/special/gatsby';
+import parser from '../../src/special/gatsby';
+import { getTestParserWithContentPromise } from '../utils';
+
+const testParser = getTestParserWithContentPromise(parser);
 
 const plugins = ['gatsby-plugin-sass', 'gatsby-plugin-react-helmet'];
 
 describe('gatsby special parser', () => {
-  it('should ignore when it is not `gatsby-config`', () => {
-    const result = gatsbySpecialParser('content', '/a/file');
+  it('should ignore when it is not `gatsby-config`', async () => {
+    const result = await parser('/a/file');
     result.should.deepEqual([]);
   });
 
-  it('should recognize the parser used by gatsby', () => {
+  it('should recognize the parser used by gatsby', async () => {
     const content = `module.exports = { plugins : ${JSON.stringify(plugins)} }`;
 
-    const result = gatsbySpecialParser(content, '/a/gatsby-config.js');
+    const result = await testParser(content, '/a/gatsby-config.js');
     result.should.deepEqual([
       'gatsby-plugin-sass',
       'gatsby-plugin-react-helmet',

--- a/test/special/gulp-load-plugins.js
+++ b/test/special/gulp-load-plugins.js
@@ -1,9 +1,12 @@
 import 'should';
-import parse from '../../src/special/gulp-load-plugins';
+import parser from '../../src/special/gulp-load-plugins';
+import { getTestParserWithContentPromise } from '../utils';
+
+const testParser = getTestParserWithContentPromise(parser);
 
 describe('gulp-load-plugins special parser', () => {
-  it('should ignore when file is not `gulpfile.js`', () => {
-    const result = parse('content', '/path/to/not-gulpfile.js', [], '/path/to');
+  it('should ignore when file is not `gulpfile.js`', async () => {
+    const result = await parser('/path/to/not-gulpfile.js', [], '/path/to');
     result.should.deepEqual([]);
   });
 
@@ -48,9 +51,9 @@ describe('gulp-load-plugins special parser', () => {
 
   ['gulpfile.js', 'gulpfile.babel.js'].forEach((gulpFileName) =>
     Object.keys(testCases).forEach((name) =>
-      it(`should recognize ${name}`, () => {
+      it(`should recognize ${name}`, async () => {
         const testCase = testCases[name];
-        const result = parse(
+        const result = await testParser(
           testCase.code,
           `/path/to/${gulpFileName}`,
           [testCase.dependency, 'gulp-load-plugins'],

--- a/test/special/husky.js
+++ b/test/special/husky.js
@@ -1,13 +1,16 @@
 import 'should';
-import parse from '../../src/special/husky';
+import parser from '../../src/special/husky';
+import { getTestParserWithContentPromise } from '../utils';
+
+const testParser = getTestParserWithContentPromise(parser);
 
 describe('husky special parser', () => {
-  it('should ignore when filename is not supported', () => {
-    const result = parse('content', 'not-supported.txt', [], '/root/dir');
+  it('should ignore when filename is not supported', async () => {
+    const result = await parser('not-supported.txt', [], '/root/dir');
     result.should.deepEqual([]);
   });
 
-  it('should detect husky when used', () => {
+  it('should detect husky when used', async () => {
     const expected = ['husky'];
     const content = JSON.stringify({
       husky: {
@@ -16,7 +19,7 @@ describe('husky special parser', () => {
         },
       },
     });
-    const actual = parse(content, '/path/to/package.json');
+    const actual = await testParser(content, '/path/to/package.json');
     actual.should.deepEqual(expected);
   });
 });

--- a/test/special/istanbul.js
+++ b/test/special/istanbul.js
@@ -1,15 +1,17 @@
 import 'should';
-import path from 'path';
-import parse from '../../src/special/istanbul';
+import parser from '../../src/special/istanbul';
 import { clearCache } from '../../src/utils/get-scripts';
+import { getTestParserWithContentPromise } from '../utils';
+
+const testParser = getTestParserWithContentPromise(parser);
 
 describe('istanbul (nyc) special parser', () => {
   beforeEach(() => {
     clearCache();
   });
 
-  it('should ignore when filename is not supported', () => {
-    const result = parse('content', 'not-supported.txt', ['unused'], __dirname);
+  it('should ignore when filename is not supported', async () => {
+    const result = await parser('not-supported.txt', ['unused'], __dirname);
     result.should.deepEqual([]);
   });
 
@@ -20,11 +22,11 @@ describe('istanbul (nyc) special parser', () => {
     '.nycrc.yaml',
     'nyc.config.js',
   ].forEach((filename) => {
-    it(`should recognize dependencies specified in configuration file ${filename}`, () => {
+    it(`should recognize dependencies specified in configuration file ${filename}`, async () => {
       const content =
         '{"extends": ["simple", "@namespace/module", "sub/module", "@sub/ns/module"], "all": true}';
-      const optPath = path.resolve(__dirname, filename);
-      const result = parse(
+      const optPath = filename;
+      const result = await testParser(
         content,
         optPath,
         [
@@ -46,10 +48,15 @@ describe('istanbul (nyc) special parser', () => {
     });
   });
 
-  it('should recognize dependencies specified in package.json configuration', () => {
+  it('should recognize dependencies specified in package.json configuration', async () => {
     const content = '{"nyc": {"extends": "simple", "skip-full": true}}';
-    const optPath = path.resolve(__dirname, 'package.json');
-    const result = parse(content, optPath, ['simple', 'unused'], __dirname);
+    const optPath = 'package.json';
+    const result = await testParser(
+      content,
+      optPath,
+      ['simple', 'unused'],
+      __dirname,
+    );
     result.should.deepEqual(['simple']);
   });
 });

--- a/test/special/lint-staged.js
+++ b/test/special/lint-staged.js
@@ -1,13 +1,16 @@
 import 'should';
-import parse from '../../src/special/lint-staged';
+import parser from '../../src/special/lint-staged';
+import { getTestParserWithContentPromise } from '../utils';
+
+const testParser = getTestParserWithContentPromise(parser);
 
 describe('lint-staged special parser', () => {
-  it('should ignore when filename is not supported', () => {
-    const result = parse('content', 'not-supported.txt', [], '/root/dir');
+  it('should ignore when filename is not supported', async () => {
+    const result = await parser('not-supported.txt', [], '/root/dir');
     result.should.deepEqual([]);
   });
 
-  it('should detect lint-staged when used', () => {
+  it('should detect lint-staged when used', async () => {
     const expected = ['lint-staged'];
     const content = JSON.stringify({
       'lint-staged': {
@@ -15,7 +18,7 @@ describe('lint-staged special parser', () => {
         '*.{js,jsx,ts,tsx}': 'eslint --ext .js,.ts,.tsx',
       },
     });
-    const actual = parse(content, '/path/to/package.json');
+    const actual = await testParser(content, '/path/to/package.json');
     actual.should.deepEqual(expected);
   });
 });

--- a/test/special/prettier.js
+++ b/test/special/prettier.js
@@ -1,16 +1,11 @@
 import 'should';
-import fs from 'fs';
 import path from 'path';
-import parse from '../../src/special/prettier';
+import parser from '../../src/special/prettier';
 
-function testPrettier(moduleName, fileName, expectedDeps) {
+async function testPrettier(moduleName, fileName, expectedDeps) {
   const rootDir = path.resolve(__dirname, '../fake_modules', moduleName);
-  const content = fs.readFileSync(
-    path.resolve(rootDir, 'package.json'),
-    'utf8',
-  );
   const deps = ['dummy', '@company/prettier-config'];
-  const result = parse(content, path.resolve(rootDir, fileName), deps, rootDir);
+  const result = await parser(path.resolve(rootDir, fileName), deps, rootDir);
   Array.from(result).should.deepEqual(expectedDeps);
 }
 

--- a/test/special/ttypescript.js
+++ b/test/special/ttypescript.js
@@ -1,7 +1,10 @@
 import 'should';
-import path from 'path';
-import fse from 'fs-extra';
-import parse from '../../src/special/ttypescript';
+import parser from '../../src/special/ttypescript';
+import { getTestParserWithTempFile } from '../utils';
+
+// NOTE: we can't use getTestParserWithContentPromise here
+// because the parser is using readJSON which is a require
+const testParser = getTestParserWithTempFile(parser);
 
 const configFileNames = ['tsconfig.json', 'tsconfig.bundle.json'];
 
@@ -20,31 +23,9 @@ const testCases = [
   },
 ];
 
-function random() {
-  return Math.random()
-    .toString()
-    .substring(2);
-}
-
-async function getTempPath(filename, content) {
-  const tempFolder = path.resolve(__dirname, `temp-${random()}`);
-  const tempPath = path.resolve(tempFolder, filename);
-  await fse.ensureDir(tempFolder);
-  await fse.outputFile(tempPath, content);
-  return tempPath;
-}
-
-async function removeTempFile(filepath) {
-  const fileFolder = path.dirname(filepath);
-  await fse.remove(filepath);
-  await fse.remove(fileFolder);
-}
-
 async function testTTypeScript(filename, content, expectedDeps) {
-  const tempPath = await getTempPath(filename, content);
   const deps = ['dummy', ...expectedDeps];
-  const result = parse(content, tempPath, deps, __dirname);
-  await removeTempFile(tempPath);
+  const result = await testParser(content, filename, deps, __dirname);
   Array.from(result).should.deepEqual(expectedDeps);
 }
 


### PR DESCRIPTION
The fix in https://github.com/depcheck/depcheck/pull/502 was a meant to be simple but it was not addressing the design flaw. `depcheck` should only read the content of the file when it's needed.

When looking a comment from 3 years go https://github.com/depcheck/depcheck/issues/131#issuecomment-202201559, seems this refactor was on the radar.

What we do here:

- Stop reading `content` in `getDependencies`
- Stop passing `content` to `parsers`, `specials`, `getScripts` and `loadConfig`
- Read `content` using `getContent` when needed in `parsers`, `specials`, `getScripts` and `loadConfig`
- Assume `parsers` and `specials` can now be asynchronous
- Make `getScripts` and `loadConfig` asynchronous
- Rename `filePath` to `filename` for consistency across the code base
- Rename `ast` to `result` because it is not necessary an "ast" when it's returned from specials.
