### PR TITLE
Feat: add special `angular` detector

### DIFF
--- a/src/special/angular.js
+++ b/src/special/angular.js
@@ -5,7 +5,7 @@ const ANGULAR_FILES = ['angular-cli.json', 'angular.json'];
 const ANGULAR_JSON_KEYS = ['scripts', 'styles', 'assets'];
 
 const traverse = (obj, candidates) => {
-  obj.keys((k) => {
+  Object.keys(obj).forEach((k) => {
     if (obj[k] && typeof obj[k] === 'object') {
       if (ANGULAR_JSON_KEYS.includes(k)) {
         candidates.push(obj[k]);
@@ -35,7 +35,7 @@ export default async function parseAngular(filename) {
         dependencies.push(match[match.length - 1].replace('node_modules/', ''));
       }
     });
-    dependencies = dependencies.filter((d) => dependencies.includes(d));
+    dependencies = dependencies.filter((d, i) => dependencies.indexOf(d) >= i);
 
     return dependencies;
   }

--- a/src/special/angular.js
+++ b/src/special/angular.js
@@ -1,0 +1,43 @@
+import * as path from 'path';
+import { getContent } from '../utils/file';
+
+const ANGULAR_FILES = ['angular-cli.json', 'angular.json'];
+const ANGULAR_JSON_KEYS = ['scripts', 'styles', 'assets'];
+
+const traverse = (obj, candidates) => {
+  obj.keys((k) => {
+    if (obj[k] && typeof obj[k] === 'object') {
+      if (ANGULAR_JSON_KEYS.includes(k)) {
+        candidates.push(obj[k]);
+      }
+      traverse(obj[k], candidates);
+    }
+  });
+};
+
+export default async function parseAngular(filename) {
+  const basename = path.basename(filename);
+
+  if (ANGULAR_FILES.includes(basename)) {
+    const content = await getContent(filename);
+    const angularJson = JSON.parse(content);
+
+    let candidates = [];
+    traverse(angularJson, candidates);
+    candidates = candidates.flat();
+
+    let dependencies = [];
+    candidates.forEach((candidate) => {
+      const match = candidate.match(
+        /node_modules\/([a-zA-Z-])*|@([a-zA-Z-])*\/([a-zA-Z-]*)/g,
+      );
+      if (match) {
+        dependencies.push(match[match.length - 1].replace('node_modules/', ''));
+      }
+    });
+    dependencies = dependencies.filter((d) => dependencies.includes(d));
+
+    return dependencies;
+  }
+  return false;
+}

--- a/test/fake_modules/angular/package.json
+++ b/test/fake_modules/angular/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "@scoped/dedendencie": "1.0.0",
+    "unscoped": "1.0.0",
+    "@foo-scoped/dedendencie": "1.0.0",
+    "foo-unsecoped": "1.0.0"
+  }
+}

--- a/test/special/angular.js
+++ b/test/special/angular.js
@@ -1,0 +1,7 @@
+describe('angular special parser', () => {
+  it('should ignore when filename is not supported"');
+  it('should recognize when path starts with "./node_modules/"');
+  it('should recognize when path starts with "node_modules/"');
+  it('should recognize scoped dependences');
+  it('should recognize unscoped dependences');
+});


### PR DESCRIPTION
# Motivation
Angular projects can contains hidden dependencies over `angular.json` & `angular-cli.json` file.
This dependencies could be `scripts`, `styles` or `assets` from `node_modules` folder.

# Resolution

I code a simply detector for checking this file & return used dependencies.

# ⚠️  Help wanted 

I coded a skeleton for use cases I consider fits. Do you think that it fills properly? If agree, I'll implement it 😸 