### PR TITLE
fix: sass parser not working with monorepo setup

### DIFF
--- a/src/parser/sass.js
+++ b/src/parser/sass.js
@@ -17,7 +17,9 @@ export default async function parseSASS(filename, deps, rootDir) {
     .map((file) => path.relative(rootDir, file))
     .filter((file) => file.indexOf('node_modules') >= 0) // refer to node_modules
     .map((file) => file.replace(/\\/g, '/')) // normalize paths in Windows
-    .map((file) => file.substring(file.indexOf('node_modules/') + 'node_modules/'.length)) // avoid heading slash
+    .map((file) =>
+      file.substring(file.indexOf('node_modules/') + 'node_modules/'.length),
+    ) // avoid heading slash
     .map(requirePackageName)
     .uniq()
     .value();

--- a/src/parser/sass.js
+++ b/src/parser/sass.js
@@ -15,9 +15,9 @@ export default async function parseSASS(filename, deps, rootDir) {
 
   const result = lodash(stats.includedFiles)
     .map((file) => path.relative(rootDir, file))
-    .filter((file) => file.indexOf('node_modules') === 0) // refer to node_modules
+    .filter((file) => file.indexOf('node_modules') >= 0) // refer to node_modules
     .map((file) => file.replace(/\\/g, '/')) // normalize paths in Windows
-    .map((file) => file.substring('node_modules/'.length)) // avoid heading slash
+    .map((file) => file.substring(file.indexOf('node_modules/') + 'node_modules/'.length)) // avoid heading slash
     .map(requirePackageName)
     .uniq()
     .value();


### PR DESCRIPTION
In a monorepo setup, `node_modules` directory is not necessarily at the same level as `package.json`. This change ensures that parser looks at relative paths for `node_modules` as well, such as `../../node_modules/<module>`