### PR TITLE
Use promise syntax for API example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ const options = {
   },
 };
 
-depcheck('/path/to/your/project', options, (unused) => {
+depcheck('/path/to/your/project', options).then(unused => {
   console.log(unused.dependencies); // an array containing the unused dependencies
   console.log(unused.devDependencies); // an array containing the unused devDependencies
   console.log(unused.missing); // a lookup containing the dependencies missing in `package.json` and where they are used


### PR DESCRIPTION
Depcheck's readme recommends using an old school callback syntax, which confusingly doesn't actually follow the error-first convention for Node callbacks, so it's not compatible with `promisify` etc.

It turns out depcheck *does* return a promise, so promisification is unnecessary. But this isn't documented (except in a comment on issue #146), and I just wasted a silly amount of time trying to figure out why my promisified version of it was always being rejected with what appeared to be a successful result. To avoid others going down this same rabbit hole, I suggest updating the readme to use the promise syntax, as this is the modern way to do it, and it will signal to people that they can use it with `async/await` etc.