### PR TITLE
Improved webpack support

### DIFF
--- a/src/detector/extract.js
+++ b/src/detector/extract.js
@@ -3,8 +3,13 @@
 export function extractInlineWebpack(value) {
   const parts = value.split('!');
   if (parts.length === 1) {
-    return value;
+    return [value]; // ['module-name'] or ['path/to/file']
   }
-
-  return parts.pop();
+  if (parts[0] === '') {
+    // ['', 'something-loader', 'path/to/file']
+    // ignore first item
+    return parts.slice(1);
+  }
+  // ['something-loader', 'another-loader', 'path/to/file']
+  return parts;
 }

--- a/src/detector/importDeclaration.js
+++ b/src/detector/importDeclaration.js
@@ -2,6 +2,6 @@ import { extractInlineWebpack } from './extract';
 
 export default function detectImportDeclaration(node) {
   return node.type === 'ImportDeclaration' && node.source && node.source.value
-    ? [extractInlineWebpack(node.source.value)]
+    ? extractInlineWebpack(node.source.value)
     : [];
 }

--- a/src/detector/requireCallExpression.js
+++ b/src/detector/requireCallExpression.js
@@ -13,7 +13,7 @@ export default function requireCallExpression(node) {
       node.arguments[0].type === 'StringLiteral'
     ) {
       return typeof node.arguments[0].value === 'string'
-        ? [extractInlineWebpack(node.arguments[0].value)]
+        ? extractInlineWebpack(node.arguments[0].value)
         : [];
     }
 
@@ -22,7 +22,7 @@ export default function requireCallExpression(node) {
       node.arguments[0].quasis.length === 1 &&
       node.arguments[0].expressions.length === 0
     ) {
-      return [extractInlineWebpack(node.arguments[0].quasis[0].value.raw)];
+      return extractInlineWebpack(node.arguments[0].quasis[0].value.raw);
     }
   }
   return [];

--- a/src/detector/typescriptImportEqualsDeclaration.js
+++ b/src/detector/typescriptImportEqualsDeclaration.js
@@ -4,6 +4,6 @@ export default function detectTypescriptImportEqualsDeclaration(node) {
   return node.type === 'TSImportEqualsDeclaration' &&
     node.moduleReference &&
     node.moduleReference.expression
-    ? [extractInlineWebpack(node.moduleReference.expression.value)]
+    ? extractInlineWebpack(node.moduleReference.expression.value)
     : [];
 }

--- a/src/special/webpack.js
+++ b/src/special/webpack.js
@@ -121,6 +121,14 @@ function parseEntries(entries, deps) {
 }
 
 function parseWebpackConfig(webpackConfig, deps) {
+  if (Array.isArray(webpackConfig)) {
+    return webpackConfig.reduce((accumulator, currentValue) => {
+      const currentResults = parseWebpackConfig(currentValue, deps);
+      Array.prototype.push.apply(accumulator, currentResults);
+      return accumulator;
+    }, []);
+  }
+
   const module = webpackConfig.module || {};
   const entry = webpackConfig.entry || [];
 

--- a/test/fake_modules/webpack_inline_loader/index.js
+++ b/test/fake_modules/webpack_inline_loader/index.js
@@ -2,3 +2,5 @@
 import 'script-loader!slick-carousel';
 
 require('script-loader!slick-carousel');
+
+require('!another-loader!slick-carousel');

--- a/test/spec.js
+++ b/test/spec.js
@@ -764,13 +764,18 @@ export default [
     expected: {
       dependencies: [],
       devDependencies: [],
-      missing: {},
+      missing: {
+        'another-loader': ['index.js'],
+        'script-loader': ['index.js', 'index.ts'],
+      },
       using: {
+        'another-loader': ['index.js'],
+        'script-loader': ['index.js', 'index.ts'],
         'slick-carousel': ['index.js'],
         'slickity-slick': ['index.ts'],
       },
     },
-    expectedErrorCode: 0,
+    expectedErrorCode: -1,
   },
   {
     name: 'support .depcheckignore',

--- a/test/special/webpack.js
+++ b/test/special/webpack.js
@@ -281,6 +281,16 @@ describe('webpack special parser', () => {
     ),
   );
 
+  it('should handle multiple webpack configurations in one file', () => {
+    const config = JSON.stringify([
+      { module: { loaders: [{ test: /\.js$/, loader: 'babel' }] } },
+      { module: { loaders: [{ test: /\.css$/, loader: 'css' }] } },
+    ]);
+    const content = `module.exports = ${config}`;
+    const deps = ['babel-loader', 'css-loader'];
+    return testWebpack('webpack.config.js', content, deps, deps);
+  });
+
   it('should handle styleguidist webpack configuration', () => {
     const expectedDeps = [
       'babel-loader',


### PR DESCRIPTION
This change improves support for webpack in two ways:
* Inline webpack loaders are now recognized, including chained loaders, such as:
   * `require('my-loader!file');`
   * `require('!my-loader!file');`
   * `require('one-loader!two-loader!file');`
* Array-valued webpack configurations are now supported, such as:
   * `module.exports=[{module: ...}, {module: ...}];`
   * See here for more info: https://webpack.js.org/configuration/configuration-types/#exporting-multiple-configurations

Tests are included for these new features.