### PR TITLE
Support react >= 17.0.0 that doesn't need to be imported

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,14 @@
         "browserslist": "^4.12.0",
         "invariant": "^2.2.4",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "@babel/core": {
@@ -146,6 +154,12 @@
             "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -248,6 +262,14 @@
         "invariant": "^2.2.4",
         "levenary": "^1.1.1",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-create-class-features-plugin": {
@@ -1994,6 +2016,12 @@
             "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -6020,6 +6048,14 @@
       "requires": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "map-cache": {
@@ -6794,6 +6830,14 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -7920,10 +7964,9 @@
       }
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "semver-compare": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "resolve": "^1.17.0",
     "sass": "^1.26.10",
     "scss-parser": "^1.0.4",
+    "semver": "^7.3.2",
     "vue-template-compiler": "^2.6.11",
     "yargs": "^15.4.0"
   },

--- a/src/special/react17.js
+++ b/src/special/react17.js
@@ -1,0 +1,20 @@
+import path from 'path';
+import semver from 'semver';
+import { getContent } from '../utils/file';
+
+export default async function parseReact17(filename) {
+  if (path.basename(filename) === 'package.json') {
+    const content = await getContent(filename);
+    const metadata = JSON.parse(content);
+
+    try {
+      if (semver.gte(semver.coerce(metadata.dependencies?.react), '17.0.0')) {
+        return ['react'];
+      }
+    } catch {
+      return [];
+    }
+  }
+
+  return [];
+}

--- a/test/special/react17.js
+++ b/test/special/react17.js
@@ -1,0 +1,43 @@
+import 'should';
+import parser from '../../src/special/react17';
+import { getTestParserWithContentPromise } from '../utils';
+
+const testParser = getTestParserWithContentPromise(parser);
+
+async function testReact17(filename, deps, content) {
+  const result = await testParser(
+    content ? JSON.stringify(content) : '',
+    filename,
+    deps,
+  );
+  result.should.deepEqual(deps);
+}
+
+describe('react17 special parser', () => {
+  it(`should report react as used if version >= 17.0.0`, () =>
+    testReact17('package.json', ['react'], {
+      name: 'my-package',
+      version: '1.0.0',
+      dependencies: {
+        react: '^17.0.0',
+      },
+    }));
+
+  it(`should not report react as used if version < 17.0.0`, () =>
+    testReact17('package.json', [], {
+      name: 'my-package',
+      version: '1.0.0',
+      dependencies: {
+        react: '^16.0.0',
+      },
+    }));
+
+  it(`should not report react if the version is invalid`, () =>
+    testReact17('package.json', [], {
+      name: 'my-package',
+      version: '1.0.0',
+      dependencies: {
+        react: 'latest',
+      },
+    }));
+});


### PR DESCRIPTION
We cheat a little bit here, if we see a react with version >=17 we
immediately say that it is used because rules of how and when this is
true are too complicated to implement with the system we have.

Fixes #591