### PR TITLE
Fix extracting dependencies from webpack

### DIFF
--- a/src/detector/extract.js
+++ b/src/detector/extract.js
@@ -8,7 +8,12 @@ export function extractInlineWebpack(value) {
   if (parts[0] === '') {
     // ['', 'something-loader', 'path/to/file']
     // ignore first item
-    return parts.slice(1);
+    const loaderParts = parts[1].split('?');
+    if (loaderParts.length === 1) {
+      return parts;
+    }
+
+    return loaderParts[0];
   }
   // ['something-loader', 'another-loader', 'path/to/file']
   return parts;

--- a/test/fake_modules/webpack_loader_with_parameters/index.js
+++ b/test/fake_modules/webpack_loader_with_parameters/index.js
@@ -1,0 +1,1 @@
+import howItWorksPageScript from '!file-loader?publicPath=/_next/static/js/&outputPath=static/js/&name=[name]-[hash].[ext]!../public/how-it-works-page/javascripts/scripts.js'; // eslint-disable-line

--- a/test/fake_modules/webpack_loader_with_parameters/package.json
+++ b/test/fake_modules/webpack_loader_with_parameters/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "file-loader": "1.0.0"
+  }
+}

--- a/test/spec.js
+++ b/test/spec.js
@@ -785,6 +785,20 @@ export default [
     expectedErrorCode: -1,
   },
   {
+    name: 'discover webpack inline loaders with parameters',
+    module: 'webpack_loader_with_parameters',
+    options: {},
+    expected: {
+      dependencies: [],
+      devDependencies: [],
+      missing: {},
+      using: {
+        'file-loader': ['index.js'],
+      },
+    },
+    expectedErrorCode: 0,
+  },
+  {
     name: 'support .depcheckignore',
     module: 'depcheckignore',
     options: {},


### PR DESCRIPTION
When using an inline loader with parameters