### PR TITLE
fix: fixing broken gatsby parser

### DIFF
--- a/src/special/gatsby.js
+++ b/src/special/gatsby.js
@@ -6,8 +6,11 @@ import { getContent } from '../utils/file';
 
 function findStringPlugins(pluginElementsArray) {
   return pluginElementsArray
-    .filter((e) => e.type === 'StringLiteral')
-    .map((e) => e.value);
+    .filter((e) => e.type === 'StringLiteral' || e.type === 'TemplateLiteral')
+    .map((e) => {
+      if (e.type === 'TemplateLiteral') return e.quasis[0].value.cooked;
+      return e.value;
+    });
 }
 
 function findResolvePlugins(pluginElementsArray) {
@@ -17,11 +20,17 @@ function findResolvePlugins(pluginElementsArray) {
     .reduce((acc, props) => acc.concat(props), [])
     .filter(
       (resolvePropCandidate) =>
-        resolvePropCandidate.key.value === 'resolve' &&
+        (resolvePropCandidate.key.name === 'resolve' ||
+          resolvePropCandidate.key.value === 'resolve') &&
         resolvePropCandidate.value &&
-        resolvePropCandidate.value.type === 'StringLiteral',
+        (resolvePropCandidate.value.type === 'StringLiteral' ||
+          resolvePropCandidate.value.type === 'TemplateLiteral'),
     )
-    .map((resolveProp) => resolveProp.value.value);
+    .map((resolveProp) => {
+      if (resolveProp.value.type === 'TemplateLiteral')
+        return resolveProp.value.quasis[0].value.cooked;
+      return resolveProp.value.value;
+    });
 }
 
 function findNestedPlugins(pluginElementsArray) {
@@ -34,7 +43,8 @@ function findNestedPlugins(pluginElementsArray) {
         (optionsPropCandidate) =>
           optionsPropCandidate &&
           optionsPropCandidate.key &&
-          optionsPropCandidate.key.value === 'options' &&
+          (optionsPropCandidate.key.name === 'options' ||
+            optionsPropCandidate.key.value === 'options') &&
           optionsPropCandidate.value &&
           optionsPropCandidate.value.type === 'ObjectExpression',
       )

--- a/test/special/gatsby.js
+++ b/test/special/gatsby.js
@@ -77,4 +77,36 @@ describe('gatsby special parser', () => {
       'gatsby-remark-relative-images',
     ]);
   });
+
+  it('should recognize template literals', async () => {
+    const resolvePlugins = [
+      {
+        resolve: `gatsby-plugin-page-creator`,
+        options: {
+          plugins: [
+            {
+              resolve: `gatsby-remark-relative-images`,
+              options: {
+                name: 'uploads',
+              },
+            },
+          ],
+        },
+      },
+      `gatsby-plugin-react-helmet`,
+      'gatsby-plugin-catch-links',
+    ];
+
+    const content = `module.exports = { plugins : ${JSON.stringify(
+      resolvePlugins,
+    )} }`;
+
+    const result = await testParser(content, '/a/gatsby-config.js');
+    result.should.deepEqual([
+      'gatsby-plugin-page-creator',
+      'gatsby-plugin-react-helmet',
+      'gatsby-plugin-catch-links',
+      'gatsby-remark-relative-images',
+    ]);
+  });
 });

--- a/test/special/gatsby.js
+++ b/test/special/gatsby.js
@@ -79,27 +79,26 @@ describe('gatsby special parser', () => {
   });
 
   it('should recognize template literals', async () => {
-    const resolvePlugins = [
-      {
-        resolve: `gatsby-plugin-page-creator`,
-        options: {
-          plugins: [
-            {
-              resolve: `gatsby-remark-relative-images`,
-              options: {
-                name: 'uploads',
-              },
-            },
-          ],
-        },
-      },
-      `gatsby-plugin-react-helmet`,
-      'gatsby-plugin-catch-links',
-    ];
-
-    const content = `module.exports = { plugins : ${JSON.stringify(
-      resolvePlugins,
-    )} }`;
+    const content =
+      'module.exports = {\n' +
+      '  plugins : [\n' +
+      '    {\n' +
+      '      resolve: `gatsby-plugin-page-creator`,' +
+      '      options: {\n' +
+      '        plugins: [\n' +
+      '          {\n' +
+      '            resolve: `gatsby-remark-relative-images`,\n' +
+      '            options: {\n' +
+      '              name: "uploads",\n' +
+      '            },\n' +
+      '          },\n' +
+      '        ],\n' +
+      '      },\n' +
+      '    },\n' +
+      '    `gatsby-plugin-react-helmet`,\n' +
+      '    "gatsby-plugin-catch-links",\n' +
+      '  ],' +
+      '}';
 
     const result = await testParser(content, '/a/gatsby-config.js');
     result.should.deepEqual([


### PR DESCRIPTION
This PR fixes Gatsby config parsing by updating the names of some internal object fields and adding support for TemplateLiterals which are used in several examples.