### PR TITLE
Svelte

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,12 +56,13 @@
         "eslint-plugin-react": "^7.21.5",
         "fs-extra": "^9.0.1",
         "mocha": "^8.2.1",
-        "node-sass": "^5.0.0",
+        "node-sass": "^6.0.0",
         "nyc": "^15.1.0",
         "patch-version": "^0.1.1",
         "prettier": "^2.1.2",
         "proxyquire": "^2.1.3",
         "should": "^13.2.3",
+        "svelte": "^3.38.2",
         "typescript": "^4.0.5"
       },
       "engines": {
@@ -6673,9 +6674,9 @@
       "dev": true
     },
     "node_modules/node-sass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-5.0.0.tgz",
-      "integrity": "sha512-opNgmlu83ZCF792U281Ry7tak9IbVC+AKnXGovcQ8LG8wFaJv6cLnRlc6DIHlmNxWEexB5bZxi9SZ9JyUuOYjw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-6.0.0.tgz",
+      "integrity": "sha512-GDzDmNgWNc9GNzTcSLTi6DU6mzSPupVJoStIi7cF3GjwSE9q1cVakbvAAVSt59vzUjV9JJoSZFKoo9krbjKd2g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -6700,7 +6701,7 @@
         "node-sass": "bin/node-sass"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/node-sass/node_modules/ansi-styles": {
@@ -9072,6 +9073,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "3.38.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.38.2.tgz",
+      "integrity": "sha512-q5Dq0/QHh4BLJyEVWGe7Cej5NWs040LWjMbicBGZ+3qpFWJ1YObRmUDZKbbovddLC9WW7THTj3kYbTOFmU9fbg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/table": {
@@ -15677,9 +15687,9 @@
       "dev": true
     },
     "node-sass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-5.0.0.tgz",
-      "integrity": "sha512-opNgmlu83ZCF792U281Ry7tak9IbVC+AKnXGovcQ8LG8wFaJv6cLnRlc6DIHlmNxWEexB5bZxi9SZ9JyUuOYjw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-6.0.0.tgz",
+      "integrity": "sha512-GDzDmNgWNc9GNzTcSLTi6DU6mzSPupVJoStIi7cF3GjwSE9q1cVakbvAAVSt59vzUjV9JJoSZFKoo9krbjKd2g==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -17647,6 +17657,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "svelte": {
+      "version": "3.38.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.38.2.tgz",
+      "integrity": "sha512-q5Dq0/QHh4BLJyEVWGe7Cej5NWs040LWjMbicBGZ+3qpFWJ1YObRmUDZKbbovddLC9WW7THTj3kYbTOFmU9fbg==",
+      "dev": true
     },
     "table": {
       "version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -94,12 +94,13 @@
     "eslint-plugin-react": "^7.21.5",
     "fs-extra": "^9.0.1",
     "mocha": "^8.2.1",
-    "node-sass": "^5.0.0",
+    "node-sass": "^6.0.0",
     "nyc": "^15.1.0",
     "patch-version": "^0.1.1",
     "prettier": "^2.1.2",
     "proxyquire": "^2.1.3",
     "should": "^13.2.3",
+    "svelte": "^3.38.2",
     "typescript": "^4.0.5"
   },
   "nyc": {

--- a/src/component.json
+++ b/src/component.json
@@ -1,6 +1,15 @@
 {
   "notice": "This file is for debugging and testing only, the production one is built from `build/component.js` script.",
-  "parser": ["coffee", "es6", "es7", "jsx", "sass", "typescript", "vue"],
+  "parser": [
+    "coffee",
+    "es6",
+    "es7",
+    "jsx",
+    "sass",
+    "typescript",
+    "vue",
+    "svelte"
+  ],
   "detector": [
     "exportDeclaration",
     "expressViewEngine",

--- a/src/constants.js
+++ b/src/constants.js
@@ -57,6 +57,7 @@ export const defaultOptions = {
     '**/*.sass': availableParsers.sass,
     '**/*.scss': availableParsers.sass,
     '**/*.vue': availableParsers.vue,
+    '**/*.svelte': availableParsers.svelte,
   },
   detectors: [
     availableDetectors.importDeclaration,

--- a/src/parser/svelte.js
+++ b/src/parser/svelte.js
@@ -1,0 +1,11 @@
+import { parse } from '@babel/parser';
+import { getContent } from '../utils/file';
+
+export default async function parseSvelte(filename) {
+  const { compile } = await import('svelte/compiler');
+  const content = await getContent(filename);
+  const { js } = compile(content);
+  return parse(js.code, {
+    sourceType: 'module',
+  });
+}

--- a/test/fake_modules/svelte/App.svelte
+++ b/test/fake_modules/svelte/App.svelte
@@ -1,0 +1,7 @@
+<script>
+  import findMe from 'find-me';
+  findMe();
+
+</script>
+
+<slot />

--- a/test/fake_modules/svelte/index.js
+++ b/test/fake_modules/svelte/index.js
@@ -1,0 +1,5 @@
+import App from './App.svelte';
+
+new App({
+  target: document.getElementById('app'),
+});

--- a/test/fake_modules/svelte/index.js
+++ b/test/fake_modules/svelte/index.js
@@ -1,5 +1,0 @@
-import App from './App.svelte';
-
-new App({
-  target: document.getElementById('app'),
-});

--- a/test/fake_modules/svelte/package.json
+++ b/test/fake_modules/svelte/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "dont-find-me": "~0.0.1",
+    "find-me": "^0.1.0",
+    "svelte": "^3.38.2"
+  }
+}

--- a/test/spec.js
+++ b/test/spec.js
@@ -848,4 +848,19 @@ export default [
     },
     expectedErrorCode: -1,
   },
+  {
+    name: 'find unused dependencies in Svelte files',
+    module: 'svelte',
+    options: {},
+    expected: {
+      dependencies: ['dont-find-me'],
+      devDependencies: [],
+      missing: {},
+      using: {
+        'find-me': ['App.svelte'],
+        svelte: ['App.svelte'],
+      },
+    },
+    expectedErrorCode: -1,
+  },
 ];


### PR DESCRIPTION
Adds Svelte support, closes #650 

Had to upgrade `node-sass` to `6.0.0` as I use Node 16.x for development.
Added Svelte to `devDependencies`
Uses dynamic imports for Svelte to make it an optional dependency.

A Svelte test case is added.
The following command runs without issues:

```bash
npm run prettier-check && npm run lint && npm run test
```