### PR TITLE
feat: detect deps used with -r in package.json

### DIFF
--- a/src/special/bin.js
+++ b/src/special/bin.js
@@ -30,6 +30,8 @@ function getBinaryFeatures(dep, [key, value]) {
     key,
     `--require ${key}`,
     `--require ${key}/register`,
+    `-r ${key}`,
+    `-r ${key}/register`,
     `$(npm bin)/${key}`,
     `node_modules/.bin/${key}`,
     `./node_modules/.bin/${key}`,

--- a/test/special/bin.js
+++ b/test/special/bin.js
@@ -96,6 +96,18 @@ const testCases = [
     expected: ['binary-package'],
   },
   {
+    name: 'detect packages used with -r and /register',
+    script: 'module -r binary-entry/register',
+    dependencies: ['binary-package'],
+    expected: ['binary-package'],
+  },
+  {
+    name: 'detect packages used with -r',
+    script: 'module -r binary-entry',
+    dependencies: ['binary-package'],
+    expected: ['binary-package'],
+  },
+  {
     name: 'detect packages with single binary',
     script: 'single-binary-package --argument',
     dependencies: ['single-binary-package'],


### PR DESCRIPTION
I noticed depcheck wasn't detecting ts-node being used in one of my package.json scripts, such as:

`"test": "mocha -r ts-node/register test/**/*.ts"`

Looked like it was already detecting `--require`, but not `-r`, so I figured it made sense to add it. I found it was briefly mentioned in this issue too: https://github.com/depcheck/depcheck/issues/461