### PR TITLE
Fix scss parsing for non-import '@' keywords

### DIFF
--- a/src/parser/sass.js
+++ b/src/parser/sass.js
@@ -8,6 +8,7 @@ const createQueryWrapper = require('query-ast');
 const sass = require('sass');
 
 const IMPORT_RULE_TYPE = 'atrule';
+const IMPORT_KEYWORDS = ['import', 'use', 'forward'];
 
 function unixSlashes(packagePath) {
   return packagePath.replace(/\\/g, '/');
@@ -54,9 +55,11 @@ function parseSCSS(filename) {
   const fileContents = fs.readFileSync(filename).toString();
   const ast = parse(fileContents);
   const queryWrapper = createQueryWrapper(ast);
-  const imports = queryWrapper(IMPORT_RULE_TYPE).nodes.map(
-    (node) => node.children[2].node.value,
-  );
+  const imports = queryWrapper(IMPORT_RULE_TYPE)
+    .nodes.filter((node) =>
+      IMPORT_KEYWORDS.includes(node.children[0].node.value),
+    )
+    .map((node) => node.children[2].node.value);
 
   const result = lodash(imports)
     .filter((packagePath) => packagePath !== filename)

--- a/test/fake_modules/sass/scss2.scss
+++ b/test/fake_modules/sass/scss2.scss
@@ -1,7 +1,20 @@
 @use "@test-dep/aFile2";
 @use "mixin"; // should ignore...
 @use "sass:math"; // should show only sass...
+@import "@test-dep/aFile3";
+@forward "@test-dep/aFile4";
+
+%ignore-extend {
+  margin: 0;
+}
 
 div {
+  @extend %ignore-extend;
   font-size: $font-size;
+}
+
+@keyframes ignore-keyframes {
+  70% {
+    margin-left: 90%;
+  }
 }

--- a/test/spec.js
+++ b/test/spec.js
@@ -232,6 +232,8 @@ export default [
       missing: {
         '@test-dep/aFile': ['sass2.sass'],
         '@test-dep/aFile2': ['scss2.scss'],
+        '@test-dep/aFile3': ['scss2.scss'],
+        '@test-dep/aFile4': ['scss2.scss'],
         sass: ['scss2.scss'],
       },
       using: {
@@ -243,6 +245,8 @@ export default [
         'scss-dep': ['scss.scss'],
         '@test-dep/aFile': ['sass2.sass'],
         '@test-dep/aFile2': ['scss2.scss'],
+        '@test-dep/aFile3': ['scss2.scss'],
+        '@test-dep/aFile4': ['scss2.scss'],
         sass: ['scss2.scss'],
       },
     },


### PR DESCRIPTION
It looked like the scss parser was treating everything with `@` as an import.

I'm not super familiar with scss, but I consulted this doc for what can be an import: https://sass-lang.com/documentation/at-rules

It looks to me that only `@use`, `@import`, and `@forward` should be treated as imports.

Relates to https://github.com/depcheck/depcheck/issues/653
And https://github.com/depcheck/depcheck/issues/627#issuecomment-808093756