### PR TITLE
Ignore .idea/ 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@ test/
 build/
 coverage/
 .nyc_output
+.idea/


### PR DESCRIPTION
They were added in latest version: https://app.renovatebot.com/package-diff?name=depcheck&from=1.4.1&to=1.4.2

Such files shouldn't be published to npm