### PR TITLE
fix: allow using @types-module for typescript type-only imports

### DIFF
--- a/src/detector/importDeclaration.js
+++ b/src/detector/importDeclaration.js
@@ -1,7 +1,18 @@
 import { extractInlineWebpack } from './extract';
 
-export default function detectImportDeclaration(node) {
-  return node.type === 'ImportDeclaration' && node.source && node.source.value
-    ? extractInlineWebpack(node.source.value)
-    : [];
+export default function detectImportDeclaration(node, deps) {
+  if (node.type !== 'ImportDeclaration' || !node.source || !node.source.value) {
+    return [];
+  }
+
+  // Typescript "import type X from 'foo'" - doesn't need to depend on the
+  // actual module, instead it can rely on `@types/<module>` instead.
+  if (
+    node.importKind === 'type' &&
+    deps.includes(`@types/${node.source.value}`)
+  ) {
+    return [`@types/${node.source.value}`];
+  }
+
+  return extractInlineWebpack(node.source.value);
 }

--- a/test/fake_modules/typescript/package.json
+++ b/test/fake_modules/typescript/package.json
@@ -4,6 +4,7 @@
     "@types/org__org-pkg": "0.0.1",
     "@types/react": "0.0.1",
     "@types/node": "0.0.1",
+    "@types/typeless-module": "0.0.1",
     "react": "0.0.1",
     "ts-dep-1": "0.0.1",
     "ts-dep-2": "0.0.1",

--- a/test/fake_modules/typescript/typeOnly.ts
+++ b/test/fake_modules/typescript/typeOnly.ts
@@ -1,0 +1,5 @@
+import type { Foo } from 'typeless-module';
+
+const bar: Foo = { prop: 'here' };
+
+export default bar;

--- a/test/spec.js
+++ b/test/spec.js
@@ -213,6 +213,7 @@ export default [
         '@types/react': ['component.tsx'],
         '@types/node': ['esnext.ts'],
         '@types/org__org-pkg': ['esnext.ts'],
+        '@types/typeless-module': ['typeOnly.ts'],
         '@org/org-pkg': ['esnext.ts'],
         'ts-dep-1': ['index.ts'],
         'ts-dep-2': ['index.ts'],


### PR DESCRIPTION
Fixes #568
Fixes #526

I'm not sure if this is the best approach, given none of the other detectors seems to be using the second `deps` argument, but the alternative would be to change the returned value from an array of strings to an object that includes dependency names and an additional property for the _type_ of import, or similar.
