### PR TITLE
cli: --oneline option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ All of the arguments are optional:
 
 `--json`: Output results in JSON. When not specified, depcheck outputs in human friendly format.
 
+`--oneline`: Output results as space separated string. Useful for copy/paste.
+
 `--ignores`: A comma separated array containing package names to ignore. It can be glob expressions. Example, `--ignores="eslint,babel-*"`.
 
 `--ignore-dirs`: DEPRECATED, use ignore-patterns instead. A comma separated array containing directory names to ignore. Example, `--ignore-dirs=dist,coverage`.

--- a/src/utils/configuration-reader.js
+++ b/src/utils/configuration-reader.js
@@ -33,6 +33,7 @@ export function getCliArgs(args, version) {
     .describe('ignore-bin-package', 'Ignore package with bin entry')
     .describe('skip-missing', 'Skip calculation of missing dependencies')
     .describe('json', 'Output results to JSON')
+    .describe('oneline', 'Output results as space separated string')
     .describe('ignores', 'Comma separated package list to ignore')
     .describe(
       'ignore-dirs',


### PR DESCRIPTION
This is just an additional option.
It seems to me that this is convenient in order to simply copy and paste to terminal, like:
`npm add ...` or `npm remove ...`

##### Example

`> depcheck`

```
Unused dependencies
* unused-1
* unused-2
Missing dependencies
* missing-1: ./index.js
* missing-2: ./index.js
```

---

`> depcheck --oneline`

```
Unused dependencies
unused1 unused2
Missing dependencies
missing1 missing2
```