### PR TITLE
feat(jest): add support for jest.config.cjs

### DIFF
--- a/src/special/jest.js
+++ b/src/special/jest.js
@@ -4,7 +4,7 @@ import { getContent } from '../utils/file';
 
 const _ = lodash;
 
-const jestConfigRegex = /^jest.([^.]+\.)?conf(ig|).js(on|)$/;
+const jestConfigRegex = /^jest.([^.]+\.)?conf(ig|).(cjs|js(on|))$/;
 const supportedProperties = [
   'dependencyExtractor',
   'preset',

--- a/test/special/jest.js
+++ b/test/special/jest.js
@@ -8,10 +8,13 @@ const testParser = getTestParserWithTempFile(parser);
 
 const configFileNames = [
   'jest.config.js',
+  'jest.config.cjs',
   'jest.conf.js',
+  'jest.conf.cjs',
   'jest.config.json',
   'jest.conf.json',
   'jest.it.config.js',
+  'jest.it.config.cjs',
 ];
 
 const testCases = [
@@ -195,7 +198,7 @@ describe('jest special parser', () => {
       it(`should ${testCase.name} in config file ${fileName}`, async () => {
         const config = JSON.stringify(testCase.content);
         let content = config;
-        if (fileName.split('.').pop() === 'js') {
+        if (['js', 'cjs'].includes(fileName.split('.').pop())) {
           content = `module.exports = ${config}`;
         }
         return testJest(content, testCase.deps, testCase.deps, fileName);


### PR DESCRIPTION
As per [Jest docs on Configuring Jest](https://jestjs.io/docs/configuration), `jest.config.cjs` is a supported file format of its kind, this PR adds support to it.