### PR TITLE
Fix typescript babel config

### DIFF
--- a/src/parser/typescript.js
+++ b/src/parser/typescript.js
@@ -16,7 +16,7 @@ export default async function parseTypescript(filename) {
       'classProperties',
       'classPrivateProperties',
       'classPrivateMethods',
-      // { decorators: { decoratorsBeforeExport: true } },
+      // ['decorators', { decoratorsBeforeExport: true }],
       'decorators-legacy',
       'doExpressions',
       'dynamicImport',
@@ -31,7 +31,7 @@ export default async function parseTypescript(filename) {
       'objectRestSpread',
       'optionalCatchBinding',
       'optionalChaining',
-      { pipelineOperator: { proposal: 'minimal' } },
+      ['pipelineOperator', { proposal: 'minimal' }],
       'throwExpressions',
     ],
   });


### PR DESCRIPTION
I don't know how it's worked this whole time, since these lines haven't been changed in years, but the syntax for configuring the babel config in the typescript parser is incorrect, leading to depcheck silently skipping typescript files. All the other parsers are using this correct syntax.

fixes #673