### PR TITLE
Fix typescript declaration for specials

### DIFF
--- a/build/component.js
+++ b/build/component.js
@@ -33,7 +33,7 @@ if (process.argv.length > 2) {
       if (line === '«Components»') {
         printItemTypes('parser', 'Parser', parser);
         printItemTypes('detector', 'Detector', detector);
-        printItemTypes('special', 'Parser', special);
+        printItemTypes('special', 'SpecialParser', special);
       } else {
         console.log(line);
       }

--- a/index.d.tmpl
+++ b/index.d.tmpl
@@ -12,7 +12,7 @@ declare namespace depcheck {
   }
 
   type Parser = (content: string, filePath: string, deps: ReadonlyArray<string>, rootDir: string) => Node;
-
+  type SpecialParser = (filePath: string, deps: ReadonlyArray<string>, rootDir: string) => string[];
   type Detector = (node: Node) => ReadonlyArray<string> | string;
 
   interface PackageDependencies {
@@ -36,9 +36,9 @@ declare namespace depcheck {
       [match: string]: Parser;
     };
     detectors?: ReadonlyArray<Detector>;
-    specials?: ReadonlyArray<Parser>;
+    specials?: ReadonlyArray<SpecialParser>;
   }
-  
+
   interface Config {
     ignoreBinPackage?: Options['ignoreBinPackage'];
     skipMissing?: Options['skipMissing'];

--- a/index.d.tmpl
+++ b/index.d.tmpl
@@ -12,7 +12,7 @@ declare namespace depcheck {
   }
 
   type Parser = (content: string, filePath: string, deps: ReadonlyArray<string>, rootDir: string) => Node;
-  type SpecialParser = (filePath: string, deps: ReadonlyArray<string>, rootDir: string) => string[];
+  type SpecialParser = (filePath: string, deps: ReadonlyArray<string>, rootDir: string) => Node | string[];
   type Detector = (node: Node) => ReadonlyArray<string> | string;
 
   interface PackageDependencies {


### PR DESCRIPTION
They don't get the content as the first parameter like regular parsers do.  And they all seem to return a string array rather than an object.