### PR TITLE
Handle scoped package bin with default name

### DIFF
--- a/src/special/bin.js
+++ b/src/special/bin.js
@@ -17,7 +17,9 @@ function getBinaries(dep, dir) {
   const binMetadata = getCacheOrLoad(dep, dir);
 
   if (typeof binMetadata === 'string') {
-    return [[dep, binMetadata]];
+    // Use path.basename to discard any scope
+    // e.g. a package named "@foo/bar" creates a command named "bar"
+    return [[path.basename(dep), binMetadata]];
   }
 
   return lodash.toPairs(binMetadata);

--- a/test/special/bin.js
+++ b/test/special/bin.js
@@ -108,10 +108,22 @@ const testCases = [
     expected: ['binary-package'],
   },
   {
-    name: 'detect packages with single binary',
+    name: 'detect packages with single binary with default name',
     script: 'single-binary-package --argument',
     dependencies: ['single-binary-package'],
     expected: ['single-binary-package'],
+  },
+  {
+    name: 'detect scoped packages with single binary with default name',
+    script: 'scoped-single-binary-package --argument',
+    dependencies: ['@scoped/scoped-single-binary-package'],
+    expected: ['@scoped/scoped-single-binary-package'],
+  },
+  {
+    name: 'detect scoped packages with named binary',
+    script: 'scoped-binary-entry --argument',
+    dependencies: ['@scoped/scoped-binary-package'],
+    expected: ['@scoped/scoped-binary-package'],
   },
 ];
 

--- a/test/special/node_modules/@scoped/scoped-binary-package/package.json
+++ b/test/special/node_modules/@scoped/scoped-binary-package/package.json
@@ -1,0 +1,5 @@
+{
+  "bin": {
+    "scoped-binary-entry": "./bin/binary-exe"
+  }
+}

--- a/test/special/node_modules/@scoped/scoped-single-binary-package/package.json
+++ b/test/special/node_modules/@scoped/scoped-single-binary-package/package.json
@@ -1,0 +1,3 @@
+{
+  "bin": "./bin/binary-exe"
+}


### PR DESCRIPTION
When package.json specifies `"bin"` as just a string, it is treated as if they specified an object with the non-namespaced name of the package as the key and the bin value as the value.

See https://classic.yarnpkg.com/lang/en/docs/package-json/#toc-bin for docs

This one's been a bit of a pain to workaround because every time I run yarn it'll "optimize" the bin entry to use this feature, e.g. if I explicitly write something like this:

```
{
"name": "@foo/command",
"bin":  {
   "command": "dist/command.js"
}
```

After running `yarn` it rewrites it like this:

```
{
"name": "@foo/command",
"bin": "dist/command.js"
}
```
