### PR TITLE
Tweak Parser typescript definition

### DIFF
--- a/index.d.tmpl
+++ b/index.d.tmpl
@@ -9,7 +9,7 @@ declare function depcheck<T>(
 declare namespace depcheck {
   type Node = Record<string, any>;
 
-  type Parser = (content: string, filePath: string, deps: ReadonlyArray<string>, rootDir: string) => Node | string[];
+  type Parser = (filePath: string, deps: ReadonlyArray<string>, rootDir: string) => Node | string[];
 
   type Detector = (node: Node) => ReadonlyArray<string> | string;
 

--- a/index.d.tmpl
+++ b/index.d.tmpl
@@ -7,11 +7,9 @@ declare function depcheck<T>(
 ): Promise<T>;
 
 declare namespace depcheck {
-  interface Node {
-    [key: string]: any;
-  }
+  type Node = Record<string, any>;
 
-  type Parser = (content: string, filePath: string, deps: ReadonlyArray<string>, rootDir: string) => Node;
+  type Parser = (content: string, filePath: string, deps: ReadonlyArray<string>, rootDir: string) => Node | string[];
 
   type Detector = (node: Node) => ReadonlyArray<string> | string;
 


### PR DESCRIPTION
- Allow string array return
- Use `Record` instead of mapped type.
- Remove `content` parameter - this doesn't seem to ever be passed in
