### PR TITLE
If babel config is a function, call it to get config

### DIFF
--- a/src/special/babel.js
+++ b/src/special/babel.js
@@ -84,11 +84,31 @@ function checkOptions(deps, options = {}) {
 
 const regex = /^(\.babelrc(\.(cjs|js(on)?))?|babel\.config\.(cjs|js(on)?))?$/;
 
+function callConfigIfFunction(config) {
+  if (typeof config === 'function') {
+    return config({
+      cache: Object.assign(() => null, {
+        forever() {},
+        never() {},
+        using() {},
+        invalidate() {},
+      }),
+      caller(cb) {
+        cb({ name: 'depcheck' });
+      },
+      env() {
+        return true;
+      },
+    });
+  }
+  return config;
+}
+
 export default async function parseBabel(filename, deps, rootDir) {
   const config = await loadConfig('babel', regex, filename, rootDir);
 
   if (config) {
-    return checkOptions(deps, config);
+    return checkOptions(deps, callConfigIfFunction(config));
   }
 
   if (path.basename(filename) === 'package.json') {

--- a/test/special/babel.js
+++ b/test/special/babel.js
@@ -164,6 +164,17 @@ describe('babel special parser', () => {
     result.should.deepEqual(['babel-preset-es2015']);
   });
 
+  it('should detect babel.config.js exporting a function', async () => {
+    const content =
+      "module.exports = api => ({ presets: ['es2015'], ignore: api.env('test') ? [] : ['**/*.test.*'] })";
+
+    const result = await testParser(content, '/path/to/babel.config.js', [
+      'babel-preset-es2015',
+      'dep',
+    ]);
+    result.should.deepEqual(['babel-preset-es2015']);
+  });
+
   it('should detect babel.config.cjs', async () => {
     const content = "module.exports = { presets: ['es2015'] }";
 


### PR DESCRIPTION
When you define a `babel.config.js` you can return a function, e.g.

https://gist.github.com/gtzilla/a6ae9777a987df1ee1357df51bf9cd61

When parsing this config file, if it a returns a function the function has to be called and provided a stub implementation of that babel api.

See https://babeljs.io/docs/en/config-files#config-function-api

Fix for https://github.com/depcheck/depcheck/issues/723

