### PR TITLE
Add support for graphql imports

### DIFF
--- a/src/component.json
+++ b/src/component.json
@@ -4,6 +4,7 @@
     "coffee",
     "es6",
     "es7",
+    "graphql",
     "jsx",
     "sass",
     "typescript",

--- a/src/constants.js
+++ b/src/constants.js
@@ -52,6 +52,7 @@ export const defaultOptions = {
     '**/*.coffee': availableParsers.coffee,
     '**/*.litcoffee': availableParsers.coffee,
     '**/*.coffee.md': availableParsers.coffee,
+    '**/*.graphql': availableParsers.graphql,
     '**/*.ts': availableParsers.typescript,
     '**/*.tsx': availableParsers.typescript,
     '**/*.sass': availableParsers.sass,

--- a/src/parser/graphql.js
+++ b/src/parser/graphql.js
@@ -1,0 +1,23 @@
+const { readFileSync } = require('fs');
+const requirePackageName = require('require-package-name');
+const JSON5 = require('json5');
+
+export default function graphqlParser(filePath) {
+  const foundDeps = [];
+  const content = readFileSync(filePath, { encoding: 'utf8' });
+  const lines = content.split(/\r\n|\r|\n/);
+  lines.some((line) => {
+    if (line[0] === '#' && line.slice(1).split(' ')[0] === 'import') {
+      const importFileExpr = line.slice(1).split(' ')[1];
+      if (importFileExpr) {
+        // Need to support single and double quotes, so use JSON5
+        const importFile = JSON5.parse(importFileExpr);
+        if (importFile && typeof importFile === 'string') {
+          foundDeps.push(importFile);
+        }
+      }
+    }
+    return line.length !== 0 && line[0] !== '#';
+  });
+  return foundDeps.map((p) => requirePackageName(p)).filter(Boolean);
+}

--- a/test/fake_modules/graphql/package.json
+++ b/test/fake_modules/graphql/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "graphql-depcheck-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "unused": "*",
+    "@scope/ok": "*",
+    "ok": "*"
+  }
+}

--- a/test/fake_modules/graphql/test.graphql
+++ b/test/fake_modules/graphql/test.graphql
@@ -1,0 +1,5 @@
+#import "./foo.graphql"
+#import "ok/test.graphql"
+#import "@scope/ok/test.graphql"
+#import "@scope/missing/missing.graphql"
+#import "missing/missing.graphql"

--- a/test/spec.js
+++ b/test/spec.js
@@ -868,4 +868,24 @@ export default [
     },
     expectedErrorCode: -1,
   },
+  {
+    name: 'find dependencies in graphql files',
+    module: 'graphql',
+    options: {},
+    expected: {
+      dependencies: ['unused'],
+      devDependencies: [],
+      missing: {
+        '@scope/missing': ['test.graphql'],
+        missing: ['test.graphql'],
+      },
+      using: {
+        '@scope/missing': ['test.graphql'],
+        '@scope/ok': ['test.graphql'],
+        missing: ['test.graphql'],
+        ok: ['test.graphql'],
+      },
+    },
+    expectedErrorCode: -1,
+  },
 ];


### PR DESCRIPTION
This scans graphql documents for imports using the format supported by `graphql-tag` and some other graphql tools.

Fixes https://github.com/depcheck/depcheck/issues/722
