### PR TITLE
Support scoped dependencies in jest configs

### DIFF
--- a/src/special/jest.js
+++ b/src/special/jest.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import lodash from 'lodash';
+import requirePackageName from 'require-package-name';
 import { getContent } from '../utils/file';
 
 const _ = lodash;
@@ -56,7 +57,7 @@ function removeNodeModuleRelativePaths(filepath) {
   if (Array.isArray(filepath)) {
     return removeNodeModuleRelativePaths(filepath[0]);
   }
-  return filepath.replace(/^.*node_modules\//, '').replace(/\/.*/, '');
+  return requirePackageName(filepath.replace(/^.*node_modules\//, ''));
 }
 
 function filter(deps, options) {

--- a/test/special/jest.js
+++ b/test/special/jest.js
@@ -70,6 +70,16 @@ const testCases = [
     },
   },
   {
+    name: 'recognize scoped dependencies',
+    deps: ['vue-jest', '@swc/jest'],
+    content: {
+      transform: {
+        '^.+\\.vue$': 'vue-jest',
+        '^.+\\.ts$': '@swc/jest',
+      },
+    },
+  },
+  {
     name: 'recognize duplicated transformer',
     deps: ['babel-jest'],
     content: {


### PR DESCRIPTION
The logic before was just stripping the first `/` and anything after that, which doesn't work for scoped dependencies (e.g. `@swc/jest`).

This fixes that by using the same `require-package-name` logic as is used in some of the other parsers.
