### PR TITLE
Allow jest import errors to escape and be reported as parse errors

### DIFF
--- a/src/special/jest.js
+++ b/src/special/jest.js
@@ -94,13 +94,9 @@ function checkOptions(deps, options = {}) {
 export default async function parseJest(filename, deps, rootDir) {
   const basename = path.basename(filename);
   if (jestConfigRegex.test(basename)) {
-    try {
-      // eslint-disable-next-line global-require
-      const options = require(filename) || {};
-      return checkOptions(deps, options);
-    } catch (error) {
-      return [];
-    }
+    // eslint-disable-next-line global-require
+    const options = require(filename) || {};
+    return checkOptions(deps, options);
   }
 
   const packageJsonPath = path.resolve(rootDir, 'package.json');


### PR DESCRIPTION
I spent quite some time trying to figure out why some jest dependencies were not being picked up, and it turns out it was because of an error loading the jest config.  Since depcheck does handle and report errors from the parser nicely it seems better to let these import errors pass out to depcheck to be handled that way rather than silently suppressing them.
