### PR TITLE
Use createRequire to import files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,11 +16,16 @@ import {
 
 function registerTs(rootDir) {
   if (!require.extensions['.ts']) {
-    const ts = tryRequire('typescript', [rootDir, process.cwd(), __dirname]);
+    const ts = tryRequire('typescript', rootDir, [
+      rootDir,
+      process.cwd(),
+      __dirname,
+    ]);
     if (ts) {
       require.extensions['.ts'] = (module, filename) => {
         const content = fs.readFileSync(filename, 'utf8');
-        const options = tryRequire(path.join(rootDir, 'package.json')) || {};
+        const options =
+          tryRequire(path.join(rootDir, 'package.json'), rootDir) || {};
         options.fileName = filename;
         const transpiled = ts.transpileModule(
           content.charCodeAt(0) === 0xfeff ? content.slice(1) : content,

--- a/src/special/jest.js
+++ b/src/special/jest.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import lodash from 'lodash';
 import { getContent } from '../utils/file';
+import { tryRequire } from '../utils';
 
 const _ = lodash;
 
@@ -94,13 +95,8 @@ function checkOptions(deps, options = {}) {
 export default async function parseJest(filename, deps, rootDir) {
   const basename = path.basename(filename);
   if (jestConfigRegex.test(basename)) {
-    try {
-      // eslint-disable-next-line global-require
-      const options = require(filename) || {};
-      return checkOptions(deps, options);
-    } catch (error) {
-      return [];
-    }
+    const options = tryRequire(filename) || {};
+    return checkOptions(deps, options);
   }
 
   const packageJsonPath = path.resolve(rootDir, 'package.json');

--- a/src/special/webpack.js
+++ b/src/special/webpack.js
@@ -179,18 +179,18 @@ function loadNextWebpackConfig(filepath) {
   return null;
 }
 
-export default function parseWebpack(filename, deps) {
+export default function parseWebpack(filename, deps, rootDir) {
   const basename = path.basename(filename);
 
   if (webpackConfigRegex.test(basename)) {
-    const webpackConfig = tryRequire(filename);
+    const webpackConfig = tryRequire(filename, rootDir);
     if (webpackConfig) {
       return parseWebpackConfig(webpackConfig, deps);
     }
   }
 
   if (basename === 'styleguide.config.js') {
-    const styleguideConfig = tryRequire(filename);
+    const styleguideConfig = tryRequire(filename, rootDir);
     if (styleguideConfig && styleguideConfig.webpackConfig) {
       return parseWebpackConfig(styleguideConfig.webpackConfig, deps);
     }

--- a/src/utils/cli-tools.js
+++ b/src/utils/cli-tools.js
@@ -83,12 +83,12 @@ export async function loadConfig(binName, filenameRegex, filename, rootDir) {
   const basename = path.basename(filename);
 
   if (filenameRegex.test(basename)) {
-    const requireConfig = tryRequire(filename);
+    const requireConfig = tryRequire(filename, rootDir);
     if (requireConfig) {
       return requireConfig;
     }
 
-    const content = await getContent(filename);
+    const content = await getContent(filename, rootDir);
     const config = parse(content);
     return config;
   }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import vm from 'vm';
+import { createRequire } from 'module';
 
 export { default as getScripts } from './get-scripts';
 
@@ -36,11 +37,19 @@ export function loadModuleData(moduleName, rootDir) {
   }
 }
 
-export function tryRequire(module, paths = []) {
+export function requireFile(
+  filePath,
+  rootDir = process.cwd(),
+  paths = undefined,
+) {
+  const targetRequire = createRequire(path.resolve(rootDir, 'package.json'));
+  const contents = targetRequire(targetRequire.resolve(filePath, paths));
+  return 'default' in contents ? contents.default : contents;
+}
+
+export function tryRequire(module, rootDir, paths) {
   try {
-    let moduleName = module;
-    if (paths.length > 0) moduleName = require.resolve(moduleName, { paths });
-    return require(moduleName); // eslint-disable-line global-require
+    return requireFile(module, rootDir, paths);
   } catch (e) {
     return null;
   }

--- a/test/special/webpack.js
+++ b/test/special/webpack.js
@@ -251,11 +251,16 @@ async function testWebpack(filename, content, deps, expectedDeps) {
 }
 
 function registerTs(rootDir) {
-  const ts = tryRequire('typescript', [rootDir, process.cwd(), __dirname]);
+  const ts = tryRequire('typescript', rootDir, [
+    rootDir,
+    process.cwd(),
+    __dirname,
+  ]);
   if (ts) {
     require.extensions['.ts'] = (module, filename) => {
       const content = fs.readFileSync(filename, 'utf8');
-      const options = tryRequire(path.join(rootDir, 'package.json')) || {};
+      const options =
+        tryRequire(path.join(rootDir, 'package.json'), rootDir) || {};
       options.fileName = filename;
       const transpiled = ts.transpileModule(
         content.charCodeAt(0) === 0xfeff ? content.slice(1) : content,


### PR DESCRIPTION
Using `createRequire` from `module` allows module resolution to proceed as if your code is running inside that project.  This means that features like `require.resolve` or `require` will be resolved relative to that project using its resolution rules.  This can avoid errors in cases where depcheck is not running as a file inside that project, or in a Yarn PnP environment where modules are not allowed to `require` other modules without a declared dependency.
