### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Depcheck not only recognizes the dependencies in JavaScript files, but also supp
 - JavaScript (ES5, ES6 and ES7)
 - [React JSX](http://facebook.github.io/react/docs/jsx-in-depth.html)
 - [CoffeeScript](http://coffeescript.org/)
-- [Typescript](http://www.typescriptlang.org/) (with `typescript` dependency)
+- [TypeScript](http://www.typescriptlang.org/) (with `typescript` dependency)
 - [SASS and SCSS](http://sass-lang.com/) (with `node-sass` dependency)
 - [Vue.js](https://vuejs.org/) (with `@vue/compiler-sfc` dependency)
 
-To get the syntax support by external dependency, please install the corresponding package explicitly. For example, for Typescript user, install depcheck with `typescript` package:
+To get the syntax support by external dependency, please install the corresponding package explicitly. For example, for TypeScript user, install depcheck with `typescript` package:
 
 ```
 npm install -g depcheck typescript
@@ -101,7 +101,7 @@ All of the arguments are optional:
 
 ## Usage with a configuration file
 
-Depcheck can be used with an rc configuration file. In order to do so, create a .depcheckrc file in your project's package.json folder, and set the CLI keys in YAML, JSON, and Javascript formats.
+Depcheck can be used with an rc configuration file. In order to do so, create a .depcheckrc file in your project's package.json folder, and set the CLI keys in YAML, JSON, and JavaScript formats.
 For example, the CLI arguments `--ignores="eslint,babel-*" --skip-missing=true` would turn into:
 
 **_.depcheckrc_**

--- a/false-alert.js
+++ b/false-alert.js
@@ -18,6 +18,6 @@ import '@babel/polyfill';
 import '@babel/register';
 
 /**
- * Typescript is loaded using tryRequire and is therefore not detected.
+ * TypeScript is loaded using tryRequire and is therefore not detected.
  */
 import 'typescript';

--- a/src/detector/importDeclaration.js
+++ b/src/detector/importDeclaration.js
@@ -5,7 +5,7 @@ export default function detectImportDeclaration(node, deps) {
     return [];
   }
 
-  // Typescript "import type X from 'foo'" - doesn't need to depend on the
+  // TypeScript "import type X from 'foo'" - doesn't need to depend on the
   // actual module, instead it can rely on `@types/<module>` instead.
   if (
     node.importKind === 'type' &&

--- a/test/fake_modules/ignore_number/index.js
+++ b/test/fake_modules/ignore_number/index.js
@@ -1,6 +1,6 @@
 /*
  * Require number is used in minify tools (e.g., browserify, webpack).
- * However, number is not a valid package for NPM.
+ * However, number is not a valid package for npm.
  * Reference: https://docs.npmjs.com/files/package.json#name
  */
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -201,7 +201,7 @@ export default [
     expectedErrorCode: 0,
   },
   {
-    name: 'support Typescript syntax',
+    name: 'support TypeScript syntax',
     module: 'typescript',
     options: {},
     expected: {


### PR DESCRIPTION
Just a few minor typo/capitalization fixes, e.g. `Typescript` -> `TypeScript`