### PR TITLE
convert object to array for babel support

### DIFF
--- a/src/parser/typescript.js
+++ b/src/parser/typescript.js
@@ -16,7 +16,7 @@ export default async function parseTypescript(filename) {
       'classProperties',
       'classPrivateProperties',
       'classPrivateMethods',
-      // { decorators: { decoratorsBeforeExport: true } },
+      // ['decorators', { decoratorsBeforeExport: true }],
       'decorators-legacy',
       'doExpressions',
       'dynamicImport',
@@ -31,7 +31,7 @@ export default async function parseTypescript(filename) {
       'objectRestSpread',
       'optionalCatchBinding',
       'optionalChaining',
-      { pipelineOperator: { proposal: 'minimal' } },
+      ['pipelineOperator', { proposal: 'minimal' }],
       'throwExpressions',
     ],
   });


### PR DESCRIPTION
babel requires arrays, other parsers have this corrected, the typescript one doesnt and latest babel versions use destructuring which fails the whole parser rather than ignore the plugin