### PR TITLE
Add parsers for mjs and cjs extensions

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -48,6 +48,8 @@ export const defaultOptions = {
   skipMissing: false,
   parsers: {
     '**/*.js': availableParsers.jsx,
+    '**/*.mjs': availableParsers.jsx,
+    '**/*.cjs': availableParsers.jsx,
     '**/*.jsx': availableParsers.jsx,
     '**/*.coffee': availableParsers.coffee,
     '**/*.litcoffee': availableParsers.coffee,


### PR DESCRIPTION
NodeJS has special JS extensions to force resolution as CommonJS (`.cjs`) and ESM (`.mjs`), the parser should be the same as the one being used for `.js` files (jsx by default)

Fixes #733