### PR TITLE
Fix type of specials

### DIFF
--- a/build/component.js
+++ b/build/component.js
@@ -33,7 +33,7 @@ if (process.argv.length > 2) {
       if (line === '«Components»') {
         printItemTypes('parser', 'Parser', parser);
         printItemTypes('detector', 'Detector', detector);
-        printItemTypes('special', 'Parser', special);
+        printItemTypes('special', 'SpecialParser', special);
       } else {
         console.log(line);
       }


### PR DESCRIPTION
Change the specials object type generator to emit them with the type `SpecialParser`.
