### PR TITLE
Fix parsing of scoped package names in jest dependencies

### DIFF
--- a/src/special/jest.js
+++ b/src/special/jest.js
@@ -56,7 +56,13 @@ function removeNodeModuleRelativePaths(filepath) {
   if (Array.isArray(filepath)) {
     return removeNodeModuleRelativePaths(filepath[0]);
   }
-  return filepath.replace(/^.*node_modules\//, '').replace(/\/.*/, '');
+  return (
+    filepath
+      .replace(/^.*node_modules\//, '')
+      // Strip off subdirectories or exports from package name,
+      // e.g. @foo/bar/baz -> @foo/bar, bar/baz -> baz
+      .replace(/^((?:@[^/]+\/)?[^@/]+)(?:\/.*)?/, '$1')
+  );
 }
 
 function filter(deps, options) {

--- a/test/special/jest.js
+++ b/test/special/jest.js
@@ -70,6 +70,16 @@ const testCases = [
     },
   },
   {
+    name: 'recognize transform path with scoped package',
+    deps: ['@swc/jest', '@swc/jest2'],
+    content: {
+      transform: {
+        '^.+\\.js$': '@swc/jest',
+        '^.+\\.jsx$': '@swc/jest2/something-else',
+      },
+    },
+  },
+  {
     name: 'recognize duplicated transformer',
     deps: ['babel-jest'],
     content: {


### PR DESCRIPTION
The jest special parser did not properly recognize scoped dependencies, for example:
```js
{
  transform: {
    '^.+\\.js$': '@swc/jest'
  }
}
```
The parser would strip off the `/jest` and was left only with `@swc`, which was then discarded. This change fixes the parsing to correctly strip off subdirectories (like `@foo/bar/baz` -> `@foo/bar`) accounting for both scoped and non-scoped package names.