### PR TITLE
Add a test for svelte+typescript

### DIFF
--- a/src/parser/svelte.js
+++ b/src/parser/svelte.js
@@ -2,10 +2,48 @@ import { parse } from '@babel/parser';
 import { getContent } from '../utils/file';
 
 export default async function parseSvelte(filename) {
-  const { compile } = await import('svelte/compiler');
+  const { preprocess } = await import('svelte/compiler');
   const content = await getContent(filename);
-  const { js } = compile(content);
-  return parse(js.code, {
+
+  let script = 'import "svelte";\n';
+  await preprocess(content, [
+    {
+      script: (svelteScript) => {
+        script += svelteScript.content;
+      },
+    },
+  ]);
+
+  return parse(script, {
     sourceType: 'module',
+    // Enable all known compatible @babel/parser plugins at the time of writing.
+    // Because we only parse them, not evaluate any code, it is safe to do so.
+    // note that babel/parser 7+ does not support *, due to plugin incompatibilities
+    plugins: [
+      'typescript',
+      'jsx',
+      'asyncGenerators',
+      'bigInt',
+      'classProperties',
+      'classPrivateProperties',
+      'classPrivateMethods',
+      // ['decorators', { decoratorsBeforeExport: true }],
+      'decorators-legacy',
+      'doExpressions',
+      'dynamicImport',
+      'exportDefaultFrom',
+      'exportNamespaceFrom',
+      'functionBind',
+      'functionSent',
+      'importMeta',
+      'logicalAssignment',
+      'nullishCoalescingOperator',
+      'numericSeparator',
+      'objectRestSpread',
+      'optionalCatchBinding',
+      'optionalChaining',
+      ['pipelineOperator', { proposal: 'minimal' }],
+      'throwExpressions',
+    ],
   });
 }

--- a/test/fake_modules/svelte_with_typescript/App.svelte
+++ b/test/fake_modules/svelte_with_typescript/App.svelte
@@ -1,0 +1,8 @@
+<script lang=ts>
+  import findMe from 'find-me';
+  const num2: number = 42;
+  findMe();
+
+</script>
+
+<slot />

--- a/test/fake_modules/svelte_with_typescript/package.json
+++ b/test/fake_modules/svelte_with_typescript/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "dont-find-me": "~0.0.1",
+    "find-me": "^0.1.0",
+    "svelte": "^3.38.2"
+  }
+}

--- a/test/spec.js
+++ b/test/spec.js
@@ -906,6 +906,21 @@ export default [
     expectedErrorCode: -1,
   },
   {
+    name: 'find unused dependencies in Svelte files with TypeScript',
+    module: 'svelte_with_typescript',
+    options: {},
+    expected: {
+      dependencies: ['dont-find-me'],
+      devDependencies: [],
+      missing: {},
+      using: {
+        'find-me': ['App.svelte'],
+        svelte: ['App.svelte'],
+      },
+    },
+    expectedErrorCode: -1,
+  },
+  {
     name: 'find dependencies in graphql files',
     module: 'graphql',
     options: {},


### PR DESCRIPTION
See #684

This fixes Svelte files that have TypeScript.  Svelte's `compile` throws an error when it sees unexpected syntax (e.g. type annotations).

I'm working around this by using Svelte's `preprocess` to grab the script content.