### PR TITLE
Convert travis to github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,29 +5,21 @@ on:
     types: [created]
 
 jobs:
-  build:
+  test:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [18.x]
+        node-version: [10.x, 18.x]
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
-
-      - name: setup git
-        if: matrix.os == 'windows-latest'
-        run: |
-          git config core.symlinks true
-          git reset --hard
-
       - name: ${{ matrix.os }} / Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
-
       - name: npm install, build, and test
         run: |
           npm ci
@@ -39,8 +31,21 @@ jobs:
           npm run prettier-check
           npm run test-coverage
 
-      - name: bump version and publish
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: build, bump version and publish
         run: |
+          npm ci
+          npm run prepublishOnly
           npm version ${{ github.ref_name }} --no-git-tag-version
           npm publish
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [18.x]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: setup git
+        if: matrix.os == 'windows-latest'
+        run: |
+          git config core.symlinks true
+          git reset --hard
+
+      - name: ${{ matrix.os }} / Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: npm install, build, and test
+        run: |
+          npm ci
+          npm run compile
+          npm run component
+          npm run depcheck
+          npm run depcheck-json
+          npm run lint
+          npm run prettier-check
+          npm run test-coverage
+
+      - name: bump version and publish
+        run: |
+          npm version ${{ github.ref_name }} --no-git-tag-version
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}


### PR DESCRIPTION
Hey 👋🏻 ,

This PR adds a github action to publish depcheck to the npm registry.
This is a requested feature per https://github.com/depcheck/depcheck/discussions/800#discussioncomment-5931935

To run this in your fork just add an npm access token to the "Actions secrets and variables" section in the project settings.
[Example](https://github.com/depcheck/depcheck/assets/12634659/2b5f3f75-e517-429b-be76-82c3caa3aa59)

To create a new release we just have to create a new semver compatible tag and publish.
https://github.com/a-rothwell/depcheck/releases/tag/123.456.789
[Screen Shot of new release](https://github.com/depcheck/depcheck/assets/12634659/53006ba2-3406-4e16-8ea3-35235aaf23f8)

This then kicks off a new action which builds, tests, and publishes the new version
[Screen shot of action](https://github.com/depcheck/depcheck/assets/12634659/66d0d3f9-b55e-4d87-93fe-70a609018807)


Resulting NPM page https://www.npmjs.com/package/arothwell-ci-test-depcheck?activeTab=versions
[Screen shot of NPM package published](https://github.com/depcheck/depcheck/assets/12634659/d65e316d-83bf-435b-85b7-5f05348217b3)

