### PR TITLE
Use json5 to parse tsconfig

### DIFF
--- a/src/parser/tsconfig.js
+++ b/src/parser/tsconfig.js
@@ -1,10 +1,11 @@
 const requirePackageName = require('require-package-name');
 const { readFileSync } = require('fs');
+const JSON5 = require('json5');
 
 export default function tsconfigParser(filePath, deps) {
   const content = readFileSync(filePath, { encoding: 'utf8' });
   const foundDeps = [];
-  const tsconfigJson = JSON.parse(content);
+  const tsconfigJson = JSON5.parse(content);
   const types = tsconfigJson.compilerOptions?.types;
   if (types) {
     types.forEach((pkg) => {


### PR DESCRIPTION
TSConfig is a jsonc  (JSON with comments) file, a proprietary format "used by a bunch of Microsoft products, most notably Typescript and VSCode"

https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html#tsconfig

> The TSConfig is a jsonc file which configures both your compiler flags, and declare where to find files.

JSON.parse is not working when there are comments but we luckily have JSON5 available in the dependencies and it can do this just fine.