### PR TITLE
Fix dynamic import with a template literal #779

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,4 +7,5 @@ test/fake_modules/node_modules/eslint-config-foo-bar/
 test/fake_modules/eslint_config_js/
 test/fake_modules/import_function/
 test/fake_modules/import_function_missing/
+test/fake_modules/import_function_template_literal/
 test/fake_modules/import_function_webpack/

--- a/src/detector/importCallExpression.js
+++ b/src/detector/importCallExpression.js
@@ -1,7 +1,8 @@
 import lodash from 'lodash';
 
 export default function importCallExpression(node) {
-  return node.type === 'CallExpression' &&
+  if (
+    node.type === 'CallExpression' &&
     node.callee &&
     ((node.callee.type === 'Identifier' && node.callee.name === 'import') ||
       node.callee.type === 'Import' ||
@@ -10,8 +11,18 @@ export default function importCallExpression(node) {
         node.callee.object.name === 'System' &&
         node.callee.property &&
         node.callee.property.name === 'import')) &&
-    node.arguments[0] &&
-    lodash.isString(node.arguments[0].value)
-    ? [node.arguments[0].value]
-    : [];
+    node.arguments[0]
+  ) {
+    if (lodash.isString(node.arguments[0].value)) {
+      return [node.arguments[0].value];
+    }
+    if (
+      node.arguments[0].type === 'TemplateLiteral' &&
+      node.arguments[0].quasis.length === 1 &&
+      lodash.isString(node.arguments[0].quasis[0].value.raw)
+    ) {
+      return [node.arguments[0].quasis[0].value.raw];
+    }
+  }
+  return [];
 }

--- a/test/fake_modules/import_function_template_literal/index.js
+++ b/test/fake_modules/import_function_template_literal/index.js
@@ -1,0 +1,1 @@
+import(`optimist`);

--- a/test/fake_modules/import_function_template_literal/package.json
+++ b/test/fake_modules/import_function_template_literal/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "optimist": "~0.6.0"
+  }
+}

--- a/test/spec.js
+++ b/test/spec.js
@@ -34,6 +34,20 @@ export default [
     expectedErrorCode: 0,
   },
   {
+    name: 'find module for dynamic import(`template-literal`) when present',
+    module: 'import_function_template_literal',
+    options: {},
+    expected: {
+      dependencies: [],
+      devDependencies: [],
+      missing: {},
+      using: {
+        optimist: ['index.js'],
+      },
+    },
+    expectedErrorCode: 0,
+  },
+  {
     name: 'find module for dynamic import() with magic Webpack comment',
     module: 'import_function_webpack',
     options: {},


### PR DESCRIPTION
Depcheck doesn't catch this

```js
import(`whatever`)
```

But with this PR, it now will catch that import.