### PR TITLE
Webpack special: add a fakePath as dir in fakeContext for next.js

### DIFF
--- a/src/special/webpack.js
+++ b/src/special/webpack.js
@@ -160,7 +160,11 @@ async function loadNextWebpackConfig(filepath) {
     watchOptions: { ignored: [] },
   };
 
-  const fakeContext = { webpack: fakeWebpack, defaultLoaders: {} };
+  const fakeContext = {
+    webpack: fakeWebpack,
+    defaultLoaders: {},
+    dir: 'fakePath',
+  };
 
   try {
     const nextConfig = await import(filepath);


### PR DESCRIPTION
Fix `loadNextWebpackConfig` to load next configs using `withSentryConfig`

Fix https://github.com/depcheck/depcheck/issues/805