### PR TITLE
fix: typescript parser add importAssertions

### DIFF
--- a/src/parser/typescript.js
+++ b/src/parser/typescript.js
@@ -33,6 +33,7 @@ export default async function parseTypescript(filename) {
       'optionalChaining',
       ['pipelineOperator', { proposal: 'minimal' }],
       'throwExpressions',
+      'importAssertions',
     ],
   });
 }


### PR DESCRIPTION
allows syntax parsing of e.g.
`import someConfig from '../someConfig.json' assert { type: 'json' };`