### PR TITLE
fix(storybook): parse package names out of addons array

### DIFF
--- a/src/parser/storybook.js
+++ b/src/parser/storybook.js
@@ -4,13 +4,13 @@ const { tryRequire } = require('../utils');
 export default function storybookParser(filePath) {
   const foundDeps = [];
   const config = tryRequire(filePath);
-  const { addons, core, framework, typescript } = config;
+  const { addons = [], core, framework, typescript } = config;
   if (typeof framework === 'string') {
     foundDeps.push(framework);
   }
-  if (Array.isArray(addons)) {
-    foundDeps.push(...addons);
-  }
+
+  foundDeps.push(...addons.map(requirePackageName));
+
   if (core) {
     const { builder } = core;
     if (builder === 'webpack5') {

--- a/test/fake_modules/storybook/.storybook/main.js
+++ b/test/fake_modules/storybook/.storybook/main.js
@@ -5,7 +5,11 @@ module.exports = {
     '../packages/**/src/**/*.stories.@(js|ts|jsx|tsx|mdx)',
   ],
   features: {},
-  addons: ['@storybook/addon-essentials', '@storybook/addon-links'],
+  addons: [
+    '@storybook/addon-essentials',
+    '@storybook/addon-links',
+    '@nx/react/plugins/storybook',
+  ],
   typescript: {
     check: false,
     checkOptions: {},

--- a/test/fake_modules/storybook/package.json
+++ b/test/fake_modules/storybook/package.json
@@ -1,6 +1,7 @@
 {
   "name": "storybook",
   "devDependencies": {
+    "@nx/react": "*",
     "@storybook/react": "*",
     "@storybook/addon-essentials": "*",
     "@storybook/addon-unused": "*",

--- a/test/spec.js
+++ b/test/spec.js
@@ -952,6 +952,7 @@ export default [
         '@storybook/manager-webpack5': ['.storybook/main.js'],
       },
       using: {
+        '@nx/react': ['.storybook/main.js'],
         '@storybook/addon-essentials': ['.storybook/main.js'],
         '@storybook/addon-links': ['.storybook/main.js'],
         '@storybook/builder-webpack5': ['.storybook/main.js'],


### PR DESCRIPTION
`addons` array can contain not only package names directly, but also nested paths to addon files within a package. Running the addons array through requirePackageName fixes that