### PR TITLE
feat(tsconfig): support tsconfig.json files with comments

### DIFF
--- a/src/parser/tsconfig.js
+++ b/src/parser/tsconfig.js
@@ -1,10 +1,12 @@
 const requirePackageName = require('require-package-name');
 const { readFileSync } = require('fs');
+const JSON5 = require('json5');
 
 export default function tsconfigParser(filePath, deps) {
   const content = readFileSync(filePath, { encoding: 'utf8' });
   const foundDeps = [];
-  const tsconfigJson = JSON.parse(content);
+  // Typescript uses 'jsonc-parser' to parse tsconfig.json, but json5 is a superset of jsonc syntax (JSON + js comments)
+  const tsconfigJson = JSON5.parse(content);
   const types = tsconfigJson.compilerOptions?.types;
   if (types) {
     types.forEach((pkg) => {


### PR DESCRIPTION
Built-in JSON.parse() doesn't allow json with comments, but `tsconfig.json` files support comments. By using `json5` instead of native JSON we prevent errors when trying to parse such json files with comments