### PR TITLE
--quiet: don't print an empty line if nothing to report

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -86,8 +86,10 @@ function print(result, log, opt, rootDir) {
         lodash.isError(value) ? value.stack : value,
       ),
     );
-  } else if (noIssue(result) && !opt.quiet) {
-    log('No depcheck issue');
+  } else if (noIssue(result)) {
+    if (!opt.quiet) {
+      log('No depcheck issue');
+    }
   } else {
     const deps = prettify(
       'Unused dependencies',


### PR DESCRIPTION
Without this change, setting --quiet would hit the third branch of the reporting code, and report... nothing, with an empty line.

Follow-up to https://github.com/depcheck/depcheck/pull/829.