### PR TITLE
Memoize `loadModuleData` to speed up depcheck runs

### DIFF
--- a/src/special/bin.js
+++ b/src/special/bin.js
@@ -2,19 +2,13 @@ import path from 'path';
 import lodash from 'lodash';
 import { loadModuleData, getScripts } from '../utils';
 
-const binaryCache = {};
-
-function getCacheOrLoad(dep, dir) {
-  const index = `${dir}/${dep}`;
-  if (!binaryCache[index]) {
-    const metadata = loadModuleData(dep, dir).metadata || {};
-    binaryCache[index] = metadata.bin || {};
-  }
-  return binaryCache[index];
+function getBinMetadata(dep, dir) {
+  const metadata = loadModuleData(dep, dir).metadata || {};
+  return metadata.bin || {};
 }
 
 function getBinaries(dep, dir) {
-  const binMetadata = getCacheOrLoad(dep, dir);
+  const binMetadata = getBinMetadata(dep, dir);
 
   if (typeof binMetadata === 'string') {
     // Use path.basename to discard any scope


### PR DESCRIPTION
While running depcheck on a large project with 100s of packages, I found that depcheck spends a lot of time resolving the package.jsons for path token it finds.

<img width="1727" alt="Screenshot 2023-10-12 at 6 16 07 PM" src="https://github.com/depcheck/depcheck/assets/8946207/b5669105-1376-4ffc-bfd3-720b962dbd1e">

Memoizing the function cut down time from ~ 59s to ~37s

