### PR TITLE
fix: detect correctly package name when importing nested file in @types package

### DIFF
--- a/src/detector/importDeclaration.js
+++ b/src/detector/importDeclaration.js
@@ -5,13 +5,14 @@ export default function detectImportDeclaration(node, deps) {
     return [];
   }
 
-  // TypeScript "import type X from 'foo'" - doesn't need to depend on the
+  // TypeScript "import type X from 'foo'" and "import type X from 'foo/bar'"- doesn't need to depend on the
   // actual module, instead it can rely on `@types/<module>` instead.
-  if (
-    node.importKind === 'type' &&
-    deps.includes(`@types/${node.source.value}`)
-  ) {
-    return [`@types/${node.source.value}`];
+
+  const packageName = node.source.value.split('/')[0];
+  const typesPackageName = `@types/${packageName}`;
+
+  if (node.importKind === 'type' && deps.includes(typesPackageName)) {
+    return [typesPackageName];
   }
 
   return extractInlineWebpack(node.source.value);

--- a/test/fake_modules/typescript/package.json
+++ b/test/fake_modules/typescript/package.json
@@ -4,6 +4,7 @@
     "@types/org__org-pkg": "0.0.1",
     "@types/react": "0.0.1",
     "@types/node": "0.0.1",
+    "@types/another-typeless-module": "0.0.1",
     "@types/typeless-module": "0.0.1",
     "react": "0.0.1",
     "ts-dep-1": "0.0.1",

--- a/test/fake_modules/typescript/typeOnly.ts
+++ b/test/fake_modules/typescript/typeOnly.ts
@@ -1,5 +1,7 @@
 import type { Foo } from 'typeless-module';
+import type { Bar } from 'another-typeless-module/nested-declaration-file';
 
-const bar: Foo = { prop: 'here' };
+const foo: Foo = { prop: 'here' };
+const bar: Bar = { prop: 'there' };
 
-export default bar;
+export default { foo, bar };

--- a/test/spec.js
+++ b/test/spec.js
@@ -227,6 +227,7 @@ export default [
         '@types/react': ['component.tsx'],
         '@types/node': ['esnext.ts'],
         '@types/org__org-pkg': ['esnext.ts'],
+        '@types/another-typeless-module': ['typeOnly.ts'],
         '@types/typeless-module': ['typeOnly.ts'],
         '@org/org-pkg': ['esnext.ts'],
         'ts-dep-1': ['index.ts'],


### PR DESCRIPTION
## Motivation
Currently `depcheck` will detect if a type is being imported and if the corresponding `@types/package-x` exists.

Some `@types` packages have types in more files other than `index.d.ts`. For example, `mdx-js` stores types in a file `mdx/types` as showed in https://mdxjs.com/docs/getting-started/#types . An example snippet that works for the TypeScript compiler but is reported as missing in `depcheck`.
```typescript
import type {MDXComponents} from 'mdx/types.js'
```

The TypeScript compiler correctly detects in this case that the package `@types/mdx` can be resolved.

While `depcheck` reports
```
Missing dependencies
* mdx: ./src/app/mdx/components/index.tsx
```

## Changes

This PR adds support for importing type declarations from nested files in `@ŧypes` packages like 

```typescript
import type { Bar } from 'another-typeless-module/nested-declaration-file';
```

Generally, it will extract the first path segment from the package path (`another-typeless-module` in the example) and use it for resolution checking. This works because the [naming rules](https://github.com/DefinitelyTyped/DefinitelyTyped?tab=readme-ov-file#naming) don't allow the substring after `@types` to contain slashes.

## Test

Added a new test to cover the scenario proposed.

1. `npm run lint` didn't introduce any new problems (there is an existing one in `src/utils/index.js#L27:10)
1. `npm run test` passed all tests
1. `npm run compile && npm run component && npm run depcheck && npm run depcheck-json` worked OK.
