### PR TITLE
feat(tsconfig): support plugins field

### DIFF
--- a/src/parser/tsconfig.js
+++ b/src/parser/tsconfig.js
@@ -7,6 +7,7 @@ export default function tsconfigParser(filePath, deps) {
   const foundDeps = [];
   // Typescript uses 'jsonc-parser' to parse tsconfig.json, but json5 is a superset of jsonc syntax (JSON + js comments)
   const tsconfigJson = JSON5.parse(content);
+
   const types = tsconfigJson.compilerOptions?.types;
   if (types) {
     types.forEach((pkg) => {
@@ -21,8 +22,17 @@ export default function tsconfigParser(filePath, deps) {
       }
     });
   }
+
   if (tsconfigJson.extends) {
     foundDeps.push(tsconfigJson.extends);
   }
+
+  const plugins = tsconfigJson.compilerOptions?.plugins;
+  if (plugins) {
+    plugins.forEach((plugin) => {
+      foundDeps.push(plugin.name);
+    });
+  }
+
   return foundDeps.map((p) => requirePackageName(p)).filter(Boolean);
 }

--- a/test/fake_modules/tsconfig/package.json
+++ b/test/fake_modules/tsconfig/package.json
@@ -4,6 +4,7 @@
   "devDependencies": {
     "@mybrand/tsconfig": "*",
     "@types/node": "*",
-    "@types/unused": "*"
+    "@types/unused": "*",
+    "typescript-eslint-language-service": "*"
   }
 }

--- a/test/fake_modules/tsconfig/tsconfig.json
+++ b/test/fake_modules/tsconfig/tsconfig.json
@@ -1,5 +1,13 @@
 {
   "compilerOptions": {
+    "plugins": [
+      {
+        "name": "typescript-eslint-language-service"
+      },
+      {
+        "name": "ts-graphql-plugin"
+      }
+    ],
     "types": ["node", "jest"]
   },
   "extends": "@mybrand/tsconfig"

--- a/test/spec.js
+++ b/test/spec.js
@@ -238,7 +238,7 @@ export default [
     expectedErrorCode: -1,
   },
   {
-    name: 'support tsconfig extends and types fields',
+    name: 'support tsconfig extends, types and plugins fields',
     module: 'tsconfig',
     options: {},
     expected: {
@@ -246,13 +246,16 @@ export default [
       devDependencies: ['@types/unused'],
       missing: {
         '@types/jest': ['tsconfig.json'],
+        'ts-graphql-plugin': ['tsconfig.json'],
         'tsconfig-base': ['tsconfig.build.json'],
       },
       using: {
         '@mybrand/tsconfig': ['tsconfig.json'],
         '@types/jest': ['tsconfig.json'],
         '@types/node': ['tsconfig.json'],
+        'ts-graphql-plugin': ['tsconfig.json'],
         'tsconfig-base': ['tsconfig.build.json'],
+        'typescript-eslint-language-service': ['tsconfig.json'],
       },
     },
     expectedErrorCode: -1,


### PR DESCRIPTION
## Motivation

Support packages being used as [Typescript language service plugins](https://www.typescriptlang.org/tsconfig#plugins)

## Changes

This PR adds support for parsing Typescript plugins as dependencies. The logic comes from the [Typescript's guide to create a plugin](https://github.com/microsoft/TypeScript/wiki/Writing-a-Language-Service-Plugin)
> To enable this plugin, users will add an entry to the plugins list in their tsconfig.json file:
```json
{
    "compilerOptions": {
	    ...
        "plugins": [{ "name": "sample-ts-plugin" }]
    }
}
```

## Test

Modified the existing `tsconfig.json` to cover the scenarios proposed.

1. `npm run lint` didn't introduce any new problems (there is an existing one in `src/utils/index.js#L27:10)
1. `npm run test` passed all tests
1. `npm run compile && npm run component && npm run depcheck && npm run depcheck-json` worked OK.
