### PR TITLE
style(utils): fix warning Unexpected unnamed function

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -24,7 +24,7 @@ export function evaluate(code) {
 function memoize(func, n) {
   const cache = new Map();
 
-  return function (...args) {
+  return (...args) => {
     const key = JSON.stringify(args);
 
     if (cache.has(key)) {


### PR DESCRIPTION
## Motivation

Improve contribution experience that [suggests running `npm run lint`](https://github.com/gmeligio/depcheck/blob/util-unnamed-function/CONTRIBUTING.md#code-style) so that the contributor knows it didn't introduce any warnings because it already existed. Alternatives are proposed below that can help with future warnings.

## Changes

1. A stylistic change that fixes an `eslint` warning by converting an unnamed function to an arrow function.

## Test

1. `npm run lint` shows no code warnings or errors.
1. `npm run test` passed all tests
1. `npm run compile && npm run component && npm run depcheck && npm run depcheck-json` worked OK.

## Alternatives

https://eslint.org/docs/latest/use/command-line-interface#handle-warnings

1. Change the eslint command to not show warnings on the terminal output `eslint --quiet`
1. Change the eslint command to error on warnings `eslint --max-warnings 0`