### PR TITLE
fix: support short name for Jest test environments

### DIFF
--- a/src/special/jest.js
+++ b/src/special/jest.js
@@ -74,6 +74,10 @@ function filter(deps, options) {
     contain(options.watchPlugins, dep, 'jest-watch-'),
   );
 
+  const testEnvironment = deps.filter((dep) =>
+    contain(options.testEnvironment, dep, 'jest-environment-'),
+  );
+
   const otherProps = lodash(options)
     .entries()
     .map(([prop, value]) => {
@@ -89,7 +93,9 @@ function filter(deps, options) {
     .intersection(deps)
     .value();
 
-  return _.uniq(runner.concat(watchPlugins).concat(otherProps));
+  return _.uniq(
+    runner.concat(watchPlugins).concat(testEnvironment).concat(otherProps),
+  );
 }
 
 function checkOptions(deps, options = {}) {

--- a/test/special/jest.js
+++ b/test/special/jest.js
@@ -53,6 +53,16 @@ const testCases = [
     content: { watchPlugins: ['master', 'select-projects'] },
   },
   {
+    name: 'recognize single short-name test environment',
+    deps: ['jest-environment-jsdom'],
+    content: { testEnvironment: 'jsdom' },
+  },
+  {
+    name: 'recognize single long-name test environment',
+    deps: ['jest-environment-jsdom'],
+    content: { testEnvironment: 'jest-environment-jsdom' },
+  },
+  {
     name: 'recognize module with options',
     deps: ['jest-watch-master'],
     content: {


### PR DESCRIPTION
Fix #857