### PR TITLE
deps: callsite -> callsites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/parser": "^7.23.0",
         "@babel/traverse": "^7.23.2",
         "@vue/compiler-sfc": "^3.3.4",
-        "callsite": "^1.0.0",
+        "callsites": "^3.1.0",
         "camelcase": "^6.3.0",
         "cosmiconfig": "^7.1.0",
         "debug": "^4.3.4",
@@ -2580,14 +2580,6 @@
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.0"
-      }
-    },
-    "node_modules/callsite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/callsites": {
@@ -9136,11 +9128,6 @@
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.0"
       }
-    },
-    "callsite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ=="
     },
     "callsites": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@babel/parser": "^7.23.0",
     "@babel/traverse": "^7.23.2",
     "@vue/compiler-sfc": "^3.3.4",
-    "callsite": "^1.0.0",
+    "callsites": "^3.1.0",
     "camelcase": "^6.3.0",
     "cosmiconfig": "^7.1.0",
     "debug": "^4.3.4",

--- a/src/utils/module-root.js
+++ b/src/utils/module-root.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import callsite from 'callsite';
+import callsites from 'callsites';
 import findup from 'findup-sync';
 import resolveFrom from 'resolve-from';
 
@@ -11,7 +11,7 @@ export default (...args) => {
   try {
     const fullpath = name
       ? resolveFrom(options.cwd, name)
-      : callsite()[1].getFileName();
+      : callsites()[1].getFileName();
     pkg = findup('package.json', { cwd: path.dirname(fullpath) });
   } catch {
     pkg = resolveFrom(options.cwd, `${args[0]}/package.json`);


### PR DESCRIPTION
The `callsite` package does not include/define a proper license, does not reference a code repository and is not actively maintained.

`callsites` v4 can't be used as it is ESM only.