### PR TITLE
fix: storybook parser for addon objects

### DIFF
--- a/src/parser/storybook.js
+++ b/src/parser/storybook.js
@@ -9,7 +9,13 @@ export default function storybookParser(filePath) {
     foundDeps.push(framework);
   }
 
-  foundDeps.push(...addons.map(requirePackageName));
+  foundDeps.push(
+    ...addons.map((addon) => {
+      if (addon.name) return requirePackageName(addon.name);
+
+      return requirePackageName(addon);
+    }),
+  );
 
   if (core) {
     const { builder } = core;


### PR DESCRIPTION
### Description
When using storybook `addons`, it's possible to specify an addon as an object. Doing so seems to cause depcheck to output the following:
```
Missing dependencies
* [object Object]: ./.storybook/main.js
```

Example config that would result in failure:
```
addons: [
    "@storybook/addon-essentials",
    "@storybook/addon-a11y",
    {
      name: "@storybook/addon-themes",
      options: {},
    },
  ],
```

This MR address the issue by taking the name property where it exists.
