### PR TITLE
add support for webpack context

### DIFF
--- a/src/special/webpack.js
+++ b/src/special/webpack.js
@@ -161,7 +161,10 @@ async function loadNextWebpackConfig(filepath) {
   };
 
   const fakeContext = {
-    webpack: fakeWebpack,
+    webpack: {
+      context: process.cwd(),
+      ...fakeWebpack,
+    },
     defaultLoaders: {},
     dir: 'fakePath',
   };

--- a/test/fake_modules/next_config/next.config.js
+++ b/test/fake_modules/next_config/next.config.js
@@ -1,5 +1,10 @@
+const path = require('path');
+
 const nextConfig = {
   webpack: (config, { webpack }) => {
+    const iconPath = path.resolve(webpack.context, './icons');
+    config.resolve.alias['@icons'] = iconPath;
+
     config.plugins.push(
       new webpack.IgnorePlugin(/[\\/]__tests__[\\/]/),
       new webpack.ContextReplacementPlugin(/moment[\\/]locale$/, /en|fr|es|ja/),

--- a/test/special/webpack.js
+++ b/test/special/webpack.js
@@ -343,7 +343,7 @@ describe('webpack special parser', () => {
     return testWebpack('styleguide.config.js', content, deps, expectedDeps);
   });
 
-  it('should handle next.js configuration', () => {
+  it.only('should handle next.js configuration', () => {
     const expectedDeps = [
       'html-loader',
       'raw-loader',


### PR DESCRIPTION
In next.js the context value for webpack is always defined: https://webpack.js.org/configuration/entry-context/#context

It is the current working directory of webpack.

Right now it set to `undefined` which breaks some webpack plugins.

fixes #880