### PR TITLE
fix: support typescript storybook config

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -56,6 +56,7 @@ export const defaultOptions = {
     '**/*.coffee.md': availableParsers.coffee,
     '**/*.graphql': availableParsers.graphql,
     '**/.storybook/main.js': availableParsers.storybook,
+    '**/.storybook/main.ts': availableParsers.storybook,
     '**/tsconfig*.json': availableParsers.tsconfig,
     '**/*.cts': availableParsers.typescript,
     '**/*.mts': availableParsers.typescript,


### PR DESCRIPTION
### Description

Storybook can be configured with typescript files, including `main.ts` as an alternative to `main.js`.

This update enables the `storybook` parser for `.storybook/main.ts`.

see https://storybook.js.org/docs/api/main-config