### PR TITLE
Add moduleNameMapper to recognized jest properties

### DIFF
--- a/src/special/jest.js
+++ b/src/special/jest.js
@@ -7,6 +7,7 @@ const _ = lodash;
 const jestConfigRegex = /^jest.([^.]+\.)?conf(ig|)\.(cjs|mjs|js|json|ts)$/;
 const supportedProperties = [
   'dependencyExtractor',
+  'moduleNameMapper',
   'preset',
   'prettierPath',
   'reporters',
@@ -81,7 +82,7 @@ function filter(deps, options) {
   const otherProps = lodash(options)
     .entries()
     .map(([prop, value]) => {
-      if (prop === 'transform') {
+      if (prop === 'transform' || prop === 'moduleNameMapper') {
         return _.values(value).map(removeNodeModuleRelativePaths);
       }
       if (Array.isArray(value)) {

--- a/test/special/jest.js
+++ b/test/special/jest.js
@@ -166,6 +166,18 @@ const testCases = [
       ],
     },
   },
+  {
+    name: 'recognize moduleNameMapper paths',
+    deps: ['hypothetical-png-mock', '@scoped/hypothetical-css-mock'],
+    content: {
+      moduleNameMapper: {
+        '@foobar/(.*)': '<rootDir>/packages/foobar/src/$1',
+        '\\.md$': '<rootDir>/mockMd.ts',
+        '\\.png$': 'hypothetical-png-mock',
+        '\\.css$': '@scoped/hypothetical-css-mock',
+      },
+    },
+  },
 ];
 
 async function testJest(content, deps, expectedDeps, _filename) {


### PR DESCRIPTION
[moduleNameMapper](https://jestjs.io/docs/configuration#modulenamemapper-objectstring-string--arraystring) is allowed to point to a npm package, for example: https://jestjs.io/docs/29.5/webpack#mocking-css-modules