### PR TITLE
use jsonc-parser to parse json files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "is-core-module": "^2.12.0",
         "js-yaml": "^3.14.1",
         "json5": "^2.2.3",
+        "jsonc-parser": "^3.2.0",
         "lodash": "^4.17.21",
         "minimatch": "^7.4.6",
         "multimatch": "^5.0.0",
@@ -4652,6 +4653,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.0.1",
@@ -10754,6 +10761,11 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+    },
+    "jsonc-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA=="
     },
     "jsonfile": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "is-core-module": "^2.12.0",
     "js-yaml": "^3.14.1",
     "json5": "^2.2.3",
+    "jsonc-parser": "^3.2.0",
     "lodash": "^4.17.21",
     "minimatch": "^7.4.6",
     "multimatch": "^5.0.0",

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,12 +1,14 @@
 import path from 'path';
 import vm from 'vm';
+import fs from 'fs';
+import { parse } from 'jsonc-parser';
 
 import moduleRoot from './module-root';
 
 export { default as getScripts } from './get-scripts';
 
 export function readJSON(filePath) {
-  return require(filePath); // eslint-disable-line global-require
+  return parse(fs.readFileSync(filePath).toString());
 }
 
 export function evaluate(code) {


### PR DESCRIPTION
Parsing JSON files with ``require()`` fails when they contain comments like in this ``tsconfig.json``:

```jsonc
{
  "compilerOptions": {
    /* Visit https://aka.ms/tsconfig to read more about this file */

    /* Projects */
    "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
    "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */

    /* ... */
  }
}
```

TypeScript will happily read that. The solution is to just use the same relaxed JSON parser TypeScript uses as well.