### PR TITLE
use json5 to parse json files in ttypescript.js

### DIFF
--- a/src/special/ttypescript.js
+++ b/src/special/ttypescript.js
@@ -1,9 +1,15 @@
 import lodash from 'lodash';
 import path from 'path';
-import { readJSON } from '../utils';
+import JSON5 from 'json5';
+import { readFileSync } from 'fs';
 
 // Search in all files looking like a TypeScript configuration file.
 const tsconfigPattern = /tsconfig(?:\.[^.]+)*\.json/;
+
+function readJSON(filename) {
+  const content = readFileSync(filename, { encoding: 'utf8' });
+  return JSON5.parse(content);
+}
 
 export default function parseTTypeScript(filename, deps) {
   const basename = path.basename(filename);


### PR DESCRIPTION
Parsing JSON files with ``require()`` fails when they contain comments like in this ``tsconfig.json``:

```jsonc
{
  "compilerOptions": {
    /* Visit https://aka.ms/tsconfig to read more about this file */

    /* Projects */
    "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
    "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */

    /* ... */
  }
}
```

TypeScript will happily read that. The solution is to use a relaxed JSON parser.