### PR TITLE
Replace `is-core-module` with `@nolyfill/is-core-module`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@babel/parser": "^7.23.0",
         "@babel/traverse": "^7.23.2",
+        "@nolyfill/is-core-module": "^1.0.39",
         "@vue/compiler-sfc": "^3.3.4",
         "callsites": "^3.1.0",
         "camelcase": "^6.3.0",
@@ -19,7 +20,6 @@
         "deps-regex": "^0.2.0",
         "findup-sync": "^5.0.0",
         "ignore": "^5.2.4",
-        "is-core-module": "^2.12.0",
         "js-yaml": "^3.14.1",
         "json5": "^2.2.3",
         "lodash": "^4.17.21",
@@ -2053,6 +2053,15 @@
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.4.0"
+      }
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -8703,6 +8712,11 @@
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
       "dev": true,
       "optional": true
+    },
+    "@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="
     },
     "@types/json5": {
       "version": "0.0.29",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@babel/parser": "^7.23.0",
     "@babel/traverse": "^7.23.2",
+    "@nolyfill/is-core-module": "^1.0.39",
     "@vue/compiler-sfc": "^3.3.4",
     "callsites": "^3.1.0",
     "camelcase": "^6.3.0",
@@ -59,7 +60,6 @@
     "deps-regex": "^0.2.0",
     "findup-sync": "^5.0.0",
     "ignore": "^5.2.4",
-    "is-core-module": "^2.12.0",
     "js-yaml": "^3.14.1",
     "json5": "^2.2.3",
     "lodash": "^4.17.21",

--- a/src/check.js
+++ b/src/check.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import debug from 'debug';
-import isCore from 'is-core-module';
+import isCore from '@nolyfill/is-core-module';
 import lodash from 'lodash';
 import readdirp from 'readdirp';
 import minimatch from 'minimatch';

--- a/src/utils/typescript.js
+++ b/src/utils/typescript.js
@@ -1,4 +1,4 @@
-import isCore from 'is-core-module';
+import isCore from '@nolyfill/is-core-module';
 
 /* eslint-disable import/prefer-default-export */
 const orgDepRegex = /@(.*?)\/(.*)/;


### PR DESCRIPTION
Node.js from v6.13.0, v8.10.0, v9.3.0 includes `module.builtinModules` which we can use to natively check if some module belongs to Node.js core or not.

This drops not one, but _three_ dependencies, removing 70 KB of bloat: https://npmgraph.js.org/?q=is-core-module