### PR TITLE
Add filename to typescript parser so it is included in the AST

### DIFF
--- a/src/parser/typescript.js
+++ b/src/parser/typescript.js
@@ -8,6 +8,7 @@ export default async function parseTypescript(filename) {
   // note that babel/parser 7+ does not support *, due to plugin incompatibilities
   return parse(content, {
     sourceType: 'module',
+    sourceFilename: filename,
     plugins: [
       'typescript',
       'jsx',


### PR DESCRIPTION
Using a custom detector, I noticed I couldn't identify where a `node` was being triggered from. Because the detector doesn't have the filename as an input, we can use the AST node to include it.