### PR TITLE
chore: drop is-core-module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "deps-regex": "^0.2.0",
         "findup-sync": "^5.0.0",
         "ignore": "^5.2.4",
-        "is-core-module": "^2.12.0",
         "js-yaml": "^3.14.1",
         "json5": "^2.2.3",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "deps-regex": "^0.2.0",
     "findup-sync": "^5.0.0",
     "ignore": "^5.2.4",
-    "is-core-module": "^2.12.0",
     "js-yaml": "^3.14.1",
     "json5": "^2.2.3",
     "lodash": "^4.17.21",

--- a/src/check.js
+++ b/src/check.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import debug from 'debug';
-import isCore from 'is-core-module';
+import { builtinModules } from 'node:module';
 import lodash from 'lodash';
 import readdirp from 'readdirp';
 import minimatch from 'minimatch';
@@ -166,7 +166,7 @@ async function getDependencies({
     .concat(peerDeps)
     .concat(optionalDeps)
     .filter((dep) => dep && dep !== '.' && dep !== '..') // TODO why need check?
-    .filter((dep) => !isCore(dep))
+    .filter((dep) => !builtinModules.includes(dep.replace('node:', '')))
     .uniq()
     .value();
 }

--- a/src/utils/typescript.js
+++ b/src/utils/typescript.js
@@ -1,4 +1,4 @@
-import isCore from 'is-core-module';
+import { builtinModules } from 'node:module';
 
 /* eslint-disable import/prefer-default-export */
 const orgDepRegex = /@(.*?)\/(.*)/;
@@ -6,7 +6,8 @@ const orgDepRegex = /@(.*?)\/(.*)/;
 // The name of the DefinitelyTyped package for a given package
 export function getAtTypesName(dep) {
   let pkgName;
-  if (isCore(dep)) {
+  const isBuiltin = builtinModules.includes(dep.replace('node:', ''));
+  if (isBuiltin) {
     pkgName = 'node';
   } else {
     const match = orgDepRegex.exec(dep);


### PR DESCRIPTION
Replaces it with node's own `builtinModules` array.

We don't yet use `isBuiltin` as it exists since 16.x but we still specify support for `>=10`.